### PR TITLE
Preserve Day One formatting and journal membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ journal-cli write --live --markdown --body-file entry.md
 
 # target a journal; link photos back to the Photos library
 journal-cli write --live --journal "Travel" --body "..." --media IMG_0079.JPG --photos-link
+
+# repair memberships written by journal-cli 1.0.6 or earlier that looked right
+# on this Mac but appeared in the default Journal on another device
+journal-cli sync-journals --live
 ```
 
 ### Editing
@@ -210,14 +214,14 @@ engine uploads them all to CloudKit — including the attachment files — and a
 delete/restore round trip propagates. The read pipeline has been swept over an
 entire real store: every entry row and all ~700 asset metadata blobs parse.
 
-The test suite (`tests/test_write.sh`, 110 assertions) runs the whole command
+The test suite (`tests/test_write.sh`, 143 assertions) runs the whole command
 surface against a disposable copy of a store — argument guards, insert
 bookkeeping, RTF round-trips, location metadata, media file layout, Live Photo
 pairing, Photos linkage, journal targeting, link assets, the delete/restore
 lifecycle, and `PRAGMA integrity_check`. Point `JOURNAL_SEED` at a backup to
 run it without Full Disk Access. `JOURNAL_CLI` selects the binary under test;
-the Python reference implementation in `reference/` passes the identical
-suite.
+the Python implementation in `reference/` remains an executable reference for
+the original command surface.
 
 ## How it works
 
@@ -240,7 +244,7 @@ the sync cache.)
 | asset metadata | one version byte `0x01` + JSON; `0x02` + UUID = Core Data external storage in `.moments_SUPPORT/_EXTERNAL_DATA/` |
 | links | base64 `NSKeyedArchiver`-archived `LPLinkMetadata` inside the asset metadata |
 | audio | asset metadata carries duration, waveform, and a word-level transcript |
-| journals | `ZJOURNALMO` (names live in each journal's CRDT blob) + `Z_5JOURNALS` join |
+| journals | `ZJOURNALMO` (names live in each journal's CRDT blob) + `Z_5JOURNALS` join; membership changes also mark the custom journal unsynced so its record is re-uploaded |
 | new-row bookkeeping | fresh `Z_PK`, bumped `Z_PRIMARYKEY.Z_MAX`, 16-byte UUID `ZID`, `ZISUPLOADEDTOCLOUD=0` — Journal's sync engine adopts the row and uploads it |
 
 ### The CRDT limitation

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ journal-cli write --live --body "At the office" \
 # web link (renders as a rich link card)
 journal-cli write --live --body "Read this" --link https://example.com --link-title "A Post"
 
+# markdown -> Journal's own rich text (bold, italic, lists, strikethrough)
+journal-cli write --live --markdown --body-file entry.md
+
 # target a journal; link photos back to the Photos library
 journal-cli write --live --journal "Travel" --body "..." --media IMG_0079.JPG --photos-link
 ```
@@ -154,6 +157,10 @@ Two more things it knows:
 - **Day One keeps media cloud-only** until asked. A journal can look complete
   in the app while almost nothing is on disk. `plan` reports the shortfall
   before you import anything.
+- **Day One writes Markdown, Journal renders rich text.** Entries are
+  converted with `--markdown`, so headings become bold, `- ` and `1. ` become
+  real lists, and Day One's `\.` escaping disappears instead of showing up
+  literally. `fix-text` re-renders entries imported before this existed.
 
 Imports are resumable, keyed by Day One's entry UUIDs, so re-running never
 double-writes.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ engine uploads them all to CloudKit — including the attachment files — and a
 delete/restore round trip propagates. The read pipeline has been swept over an
 entire real store: every entry row and all ~700 asset metadata blobs parse.
 
-The test suite (`tests/test_write.sh`, 143 assertions) runs the whole command
+The test suite (`tests/test_write.sh`, 146 assertions) runs the whole command
 surface against a disposable copy of a store — argument guards, insert
 bookkeeping, RTF round-trips, location metadata, media file layout, Live Photo
 pairing, Photos linkage, journal targeting, link assets, the delete/restore

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-journal-cli",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Read and write Apple Journal entries from the terminal. Native Swift binary; macOS only.",
   "keywords": [
     "apple",

--- a/reference/journal-cli.py
+++ b/reference/journal-cli.py
@@ -585,6 +585,19 @@ def resolve_journal(conn, sel):
     die(f"journal name {sel!r} is ambiguous; use the id: " +
         ", ".join(str(j["pk"]) for j in hits))
 
+def journal_pks_for_entry(conn, entry_pk):
+    return [r[0] for r in conn.execute(
+        "select Z_6JOURNALS from Z_5JOURNALS where Z_5ENTRIES=?", (entry_pk,))]
+
+def mark_journals_unsynced(conn, journal_pks):
+    """Queue changed custom-journal membership records for CloudKit upload."""
+    for pk in set(journal_pks):
+        conn.execute("""update ZJOURNALMO
+                        set ZISUPLOADEDTOCLOUD=0, Z_OPT=coalesce(Z_OPT,0)+1
+                        where Z_PK=?
+                          and not (ZMERGEABLEATTRIBUTES is null and ZSORTCATEGORY < 0)""",
+                     (pk,))
+
 def cmd_journals(a):
     with Snapshot() as c:
         rows = journal_rows(c)
@@ -763,6 +776,7 @@ def cmd_write(a):
             if not jdefault:
                 conn.execute("insert or ignore into Z_5JOURNALS (Z_5ENTRIES, Z_6JOURNALS) values (?,?)",
                              (pk, jpk))
+                mark_journals_unsynced(conn, [jpk])
         # no --journal: the entry lands in the default journal implicitly (no join
         # row), matching how most native entries are stored
 
@@ -929,10 +943,12 @@ def cmd_edit(a):
 
         if a.journal:
             jpk, jname, jdefault = resolve_journal(conn, a.journal)
+            old_jpks = journal_pks_for_entry(conn, a.id)
             conn.execute("delete from Z_5JOURNALS where Z_5ENTRIES=?", (a.id,))
             if not jdefault:
                 conn.execute("insert into Z_5JOURNALS (Z_5ENTRIES, Z_6JOURNALS) values (?,?)",
                              (a.id, jpk))
+            mark_journals_unsynced(conn, old_jpks + ([] if jdefault else [jpk]))
 
     bits = []
     if body is not None: bits.append("body")
@@ -964,6 +980,7 @@ def cmd_delete(a):
                 "  sync (verified). Use a soft delete (no --hard), delete it in\n"
                 "  Journal.app, or pass --force if you accept the resurrection risk.")
         if a.hard:
+            old_jpks = journal_pks_for_entry(conn, a.id)
             apks = [r[0] for r in conn.execute(
                 "select Z_PK from ZJOURNALENTRYASSETMO where ZENTRY=?", (a.id,))]
             for apk in apks:
@@ -971,6 +988,7 @@ def cmd_delete(a):
             conn.execute("delete from ZJOURNALENTRYASSETMO where ZENTRY=?", (a.id,))
             conn.execute("delete from Z_5JOURNALS where Z_5ENTRIES=?", (a.id,))
             conn.execute("delete from ZJOURNALENTRYMO where Z_PK=?", (a.id,))
+            mark_journals_unsynced(conn, old_jpks)
             eu = u_str(row["ZID"])
             if eu:
                 d = os.path.join(attach_dir(), eu)
@@ -1045,12 +1063,14 @@ def cmd_empty(a):
             if r["ZISUPLOADEDTOCLOUD"] and not a.force:
                 skipped += 1; continue
             eu = u_str(r["ZID"])
+            old_jpks = journal_pks_for_entry(conn, r["Z_PK"])
             for (apk,) in conn.execute("select Z_PK from ZJOURNALENTRYASSETMO where ZENTRY=?",
                                        (r["Z_PK"],)):
                 conn.execute("delete from ZJOURNALENTRYASSETFILEATTACHMENTMO where ZASSET=?", (apk,))
             conn.execute("delete from ZJOURNALENTRYASSETMO where ZENTRY=?", (r["Z_PK"],))
             conn.execute("delete from Z_5JOURNALS where Z_5ENTRIES=?", (r["Z_PK"],))
             conn.execute("delete from ZJOURNALENTRYMO where Z_PK=?", (r["Z_PK"],))
+            mark_journals_unsynced(conn, old_jpks)
             if eu:
                 d = os.path.join(attach_dir(), eu)
                 if os.path.isdir(d): shutil.rmtree(d, ignore_errors=True)
@@ -1061,6 +1081,29 @@ def cmd_empty(a):
                 " a local purge of synced entries resurrects them from iCloud."
                 " Empty Recently Deleted in Journal.app instead (or --force to purge anyway).")
     print(msg)
+
+def cmd_sync_journals(a):
+    def selected_rows(conn):
+        if a.journal:
+            pk, name, is_default = resolve_journal(conn, a.journal)
+            if is_default:
+                die("the default journal has no custom membership record to sync")
+            return [{"pk": pk, "name": name, "default": False}]
+        return [j for j in journal_rows(conn) if not j["default"]]
+
+    if a.dry_run:
+        with Snapshot() as conn:
+            rows = selected_rows(conn)
+        print(f"DRY RUN: would queue {len(rows)} custom journal"
+              f"{'s' if len(rows) != 1 else ''} for membership re-upload. Nothing written.")
+        return
+
+    with Live(allow_live_default=a.live, accept_risk=a.accept_risk) as conn:
+        rows = selected_rows(conn)
+        mark_journals_unsynced(conn, [j["pk"] for j in rows])
+    print(f"Queued {len(rows)} custom journal{'s' if len(rows) != 1 else ''} "
+          "for membership re-upload. Open Journal.app to sync the corrected "
+          "memberships to other devices.")
 
 def cmd_sandbox(a):
     """Seed a throwaway store. --from lets tests run off a backup without FDA."""
@@ -1189,6 +1232,14 @@ def main():
     em.add_argument("--dry-run", dest="dry_run", action="store_true")
     em.add_argument("--accept-risk", dest="accept_risk", action="store_true")
     em.add_argument("--live", action="store_true"); em.set_defaults(func=cmd_empty)
+
+    sj = sub.add_parser("sync-journals",
+                        help="re-upload custom-journal memberships after a direct-store import")
+    sj.add_argument("--journal", help="journal name or id (default: all custom journals)")
+    sj.add_argument("--dry-run", dest="dry_run", action="store_true")
+    sj.add_argument("--accept-risk", dest="accept_risk", action="store_true")
+    sj.add_argument("--live", action="store_true")
+    sj.set_defaults(func=cmd_sync_journals)
 
     d = sub.add_parser("delete"); d.add_argument("id", type=int)
     d.add_argument("--hard", action="store_true")

--- a/skills/dayone-import/SKILL.md
+++ b/skills/dayone-import/SKILL.md
@@ -86,6 +86,18 @@ journal-cli --db "$DB" journals --json      # verify counts, then spot-check
 
 Then replay the identical command without `--target-db`.
 
+Imports made with journal-cli 1.0.6 or earlier can look correctly categorized
+on the Mac while another device places every imported entry in the default
+Journal. Repair those existing memberships once with:
+
+```sh
+journal-cli sync-journals --dry-run
+journal-cli sync-journals --live
+```
+
+The repair queues the custom journal records for re-upload; it does not rewrite
+the imported entries or their media.
+
 - **The target journal must already exist** in Journal.app — create it there
   first (journal-cli cannot create journals).
 - **Quit Journal.app** before a live run; `journal-cli` refuses while it runs.

--- a/skills/dayone-import/SKILL.md
+++ b/skills/dayone-import/SKILL.md
@@ -127,12 +127,14 @@ plain while genuine `1. text` becomes a numbered list.
 ### Repairing entries imported before this existed
 
 `fix-text` re-renders imported entries from their original Markdown. It
-checks two things, because an entry can read correctly as plain text while
-having silently lost its formatting:
+decides what needs work by asking `journal-cli render` what the entry's
+source *should* produce and comparing that with what is stored, byte for
+byte.
 
-- raw Markdown still visible in the text, and
-- source constructs (headings, emphasis, lists) whose RTF markup is missing
-  from the stored entry.
+That exactness matters. Sniffing the stored text for leftover syntax cannot
+tell a correctly rendered `**literal**` (whose source was escaped) or a
+fenced `# comment` from genuinely unrendered markup, so a sniffing check
+flags those entries forever and rewrites them on every run.
 
 ```sh
 python3 $S fix-text "Omar's Journal" --dry-run     # always look first

--- a/skills/dayone-import/SKILL.md
+++ b/skills/dayone-import/SKILL.md
@@ -18,6 +18,7 @@ python3 $S import "Travel Journal" --into "Travel" --target-db "$SANDBOX"
 python3 $S import "Travel Journal" --into "Travel" --prune-backups
 python3 $S fix-export "Travel Journal" ~/path/to/export --rename --enrich --flag-missing
 python3 $S fix-locations "Travel Journal"     # repair locations from photo EXIF
+python3 $S fix-text "Travel Journal"          # re-render entries showing raw Markdown
 ```
 
 Files: `dayone.py` reads the store, `exifgps.py` is a dependency-free JPEG
@@ -98,6 +99,48 @@ Then replay the identical command without `--target-db`.
 - Stops after `--max-failures` (default 5) so a systemic problem cannot
   quietly mangle thousands of entries.
 
+## Formatting: Day One writes Markdown, Journal renders rich text
+
+Journal stores entry text as RTF and renders it, but it does not understand
+Markdown -- so syntax left in place is shown literally, and an imported
+entry reads "###### Reflect on today:" instead of a bold heading. Day One
+also escapes punctuation ("1\\." when the author meant a literal "1."),
+which surfaces as stray backslashes.
+
+The import passes the original Markdown to `journal-cli --markdown`, which
+renders the subset Journal actually supports:
+
+| Markdown | becomes |
+|---|---|
+| `# ...` through `###### ...` | bold text (Journal has no heading levels) |
+| `**bold**`, `*italic*`, `~~struck~~` | bold, italic, strikethrough |
+| `- item` / `1. item` | real bulleted and numbered lists |
+| `> quote` | an indented paragraph |
+| `[text](url)` | `text (url)` |
+| `---` rules, ``` fences | removed |
+| `\\.` `\\-` escaping | unescaped |
+
+Escaping is why list detection runs *before* unescaping: Day One writes
+"1\\. text" precisely when the author did not want a list, so those stay
+plain while genuine `1. text` becomes a numbered list.
+
+### Repairing entries imported before this existed
+
+`fix-text` re-renders imported entries from their original Markdown. It
+checks two things, because an entry can read correctly as plain text while
+having silently lost its formatting:
+
+- raw Markdown still visible in the text, and
+- source constructs (headings, emphasis, lists) whose RTF markup is missing
+  from the stored entry.
+
+```sh
+python3 $S fix-text "Omar's Journal" --dry-run     # always look first
+python3 $S fix-text "Omar's Journal"
+```
+
+Safe to re-run: a second pass reports zero entries needing work.
+
 ## Fixing wrong locations
 
 Day One stamps an entry with wherever **the app** was when the entry was
@@ -163,8 +206,8 @@ Always `--dry-run` first; it prints every rename it intends to make.
   iCloud**. Say roughly how much data that is before starting.
 - Day One may be mid-sync; its entry counts can move between runs. Re-run
   `plan` if a count looks off.
-- Day One's per-entry `activity`, weather, tags, and rich-text styling have
-  no home in Apple Journal and are dropped. Say so rather than implying
+- Day One's per-entry `activity`, weather and tags have no home in Apple
+  Journal and are dropped. Say so rather than implying
   a lossless move.
 - **Do not trust Day One's location or timezone for an entry written after
   the fact.** Both record where the app was, not where the events were. When

--- a/skills/dayone-import/scripts/dayone-import.py
+++ b/skills/dayone-import/scripts/dayone-import.py
@@ -209,6 +209,9 @@ def cmd_import(args):
 # journal-cli snapshots the whole store before every live write; across a
 # few thousand entries that is tens of GB of near-identical copies. Keep the
 # ones that predate this run, retire the rest to the Trash (never rm).
+_PRUNE_WARNED = False
+
+
 def _backup_dirs():
     root = os.path.expanduser("~/Backups/journal-cli")
     if not os.path.isdir(root):
@@ -221,11 +224,19 @@ def _prune_backups(keep):
     stale = made[:-1]                       # always keep the most recent
     if not stale:
         return
-    if shutil.which("trash"):
-        subprocess.run(["trash"] + stale, capture_output=True)
-    else:
-        for d in stale:
-            shutil.rmtree(d, ignore_errors=True)
+    if not shutil.which("trash"):
+        # These are the only copies of the store from before each write.
+        # Retiring them to the Trash is recoverable; deleting them is not, so
+        # rather than quietly destroying backups, leave them and say so.
+        global _PRUNE_WARNED
+        if not _PRUNE_WARNED:
+            _PRUNE_WARNED = True
+            sys.stderr.write(
+                "warning: `trash` is unavailable (macOS 26+), so backup "
+                "snapshots are being kept rather than deleted. Remove "
+                "~/Backups/journal-cli yourself if disk space runs short.\n")
+        return
+    subprocess.run(["trash"] + stale, capture_output=True)
 
 
 def _haversine(a, b, c, d):

--- a/skills/dayone-import/scripts/dayone-import.py
+++ b/skills/dayone-import/scripts/dayone-import.py
@@ -402,13 +402,16 @@ def _stored(cli, target_db):
     # would be matched against a different database entirely.
     db = target_db or os.environ.get("JOURNAL_DB") or os.path.expanduser(
         "~/Library/Group Containers/group.com.apple.moments/Library/moments.sqlite")
-    rtf, rtf_ok = {}, True
+    rtf, crdt, rtf_ok = {}, set(), True
     try:
         con = sqlite3.connect("file:%s?mode=ro" % db, uri=True)
-        for pk, blob in con.execute(
-                "select Z_PK, ZTEXT from ZJOURNALENTRYMO where ZTEXT is not null"):
-            rtf[pk] = (bytes(blob) if isinstance(blob, (bytes, bytearray))
-                       else str(blob).encode("utf-8"))
+        for pk, blob, merge in con.execute(
+                "select Z_PK, ZTEXT, ZMERGEABLEATTRIBUTES from ZJOURNALENTRYMO"):
+            if blob is not None:
+                rtf[pk] = (bytes(blob) if isinstance(blob, (bytes, bytearray))
+                           else str(blob).encode("utf-8"))
+            if merge is not None:
+                crdt.add(pk)
         con.close()
     except sqlite3.Error:
         # Without the RTF we cannot tell rendered from unrendered formatting.
@@ -417,7 +420,8 @@ def _stored(cli, target_db):
         rtf_ok = False
         sys.stderr.write("note: could not read entry RTF from %s; checking "
                          "visible text only.\n" % db)
-    return ({pk: (t[0], t[1], rtf.get(pk)) for pk, t in text.items()}, rtf_ok)
+    return ({pk: (t[0], t[1], rtf.get(pk)) for pk, t in text.items()},
+            rtf_ok, crdt)
 
 
 # Formatting controls that carry meaning, counted so two RTF documents can be
@@ -467,7 +471,7 @@ def cmd_fix_text(args):
     if not state["done"]:
         die("no import state at %s -- run `import` first" % state_path)
 
-    stored, rtf_ok = _stored(args.cli, args.target_db)
+    stored, rtf_ok, crdt = _stored(args.cli, args.target_db)
     if _render(args.cli, "probe") is None:
         die("%s has no `render` command -- upgrade journal-cli" % args.cli)
 
@@ -476,12 +480,19 @@ def cmd_fix_text(args):
     # a correctly rendered "**literal**" (from escaped source) or a fenced
     # "# comment" from unrendered markup, so it kept flagging good entries
     # forever. An exact comparison is idempotent by construction.
-    todo, reasons = [], collections.Counter()
+    todo, reasons, edited = [], collections.Counter(), []
     for e in entries:
         pk = state["done"].get(e["uuid"])
         if not isinstance(pk, int) or pk not in stored:
             continue
         title, text, rtf = stored[pk]
+        # An entry edited in Journal since import carries Journal's own CRDT
+        # copy of the text. journal-cli refuses to rewrite those without
+        # --force, and forcing would discard the user's edit -- so leave them
+        # alone and say which ones rather than failing partway through.
+        if pk in crdt:
+            edited.append((e, pk))
+            continue
         why = None
 
         want_title = _render(args.cli, e.get("title_md") or e["title"] or "",
@@ -509,6 +520,16 @@ def cmd_fix_text(args):
         if why:
             reasons[why] += 1
             todo.append((e, pk))
+
+    if edited:
+        print("Skipped %d entr%s edited in Journal since import (they carry "
+              "Journal's own copy of the text; re-rendering would discard "
+              "your edit):" % (len(edited), "y" if len(edited) == 1 else "ies"))
+        for e, pk in edited[:5]:
+            print("   [%s] %s" % (pk, (e["title"] or "(untitled)")[:52]))
+        if len(edited) > 5:
+            print("   ... and %d more" % (len(edited) - 5))
+        print()
 
     print("%d of %d imported entries need re-rendering."
           % (len(todo), len(state["done"])))

--- a/skills/dayone-import/scripts/dayone-import.py
+++ b/skills/dayone-import/scripts/dayone-import.py
@@ -337,8 +337,8 @@ def cmd_fix_locations(args):
         return
 
     ok = 0
-    backups_before = (set(_backup_dirs())
-                      if not args.target_db and args.prune_backups else set())
+    prune = bool(args.prune_backups) and not args.target_db
+    backups_before = set(_backup_dirs()) if prune else set()
     for n, (e, pk, got, off, place, city) in enumerate(fixes, 1):
         cmd = [args.cli]
         if args.target_db:
@@ -357,9 +357,9 @@ def cmd_fix_locations(args):
                              % (pk, (r.stderr or r.stdout).strip().split("\n")[-1]))
         else:
             ok += 1
-        if backups_before and n % 25 == 0:
+        if prune and n % 25 == 0:
             _prune_backups(backups_before)
-    if backups_before:
+    if prune:
         _prune_backups(backups_before)
     print("\nRelocated %d of %d." % (ok, len(fixes)))
 
@@ -372,6 +372,10 @@ ARTIFACTS = [
     re.compile(r"\[[^\]]+\]\([^)\s]+\)"),                 # [text](url)
 ]
 
+
+# A backslash escape and the character it protects, replaced wholesale before
+# looking for formatting so the escaped delimiter cannot match.
+ESCAPED_PAIR = re.compile(r"\\.", re.S)
 
 # Constructs in the Day One source that must survive as real formatting.
 SOURCE_FEATURES = {
@@ -448,7 +452,10 @@ def cmd_fix_text(args):
             # Only the body is stored as RTF; the title is a separate plain
             # field. Comparing title markup against the body's RTF would
             # never match and would rewrite the entry on every run.
-            source = e.get("body_md") or ""
+            # Neutralize backslash-escaped characters first: "\\*literal\\*"
+            # is not emphasis, and matching it here would report lost
+            # formatting and rewrite the same entry on every run.
+            source = ESCAPED_PAIR.sub("x", e.get("body_md") or "")
             for name, pat in SOURCE_FEATURES.items():
                 if pat.search(source) and RTF_MARKERS[name] not in rtf:
                     why = "lost %s formatting" % name
@@ -473,8 +480,10 @@ def cmd_fix_text(args):
         return
 
     ok = fail = 0
-    backups_before = (set(_backup_dirs())
-                      if not args.target_db and args.prune_backups else set())
+    # Gate on the option, not on whether the keep set happens to be non-empty:
+    # a first run against an empty ~/Backups would otherwise skip pruning.
+    prune = bool(args.prune_backups) and not args.target_db
+    backups_before = set(_backup_dirs()) if prune else set()
     for n, (e, pk) in enumerate(todo, 1):
         cmd = [args.cli]
         if args.target_db:
@@ -506,9 +515,9 @@ def cmd_fix_text(args):
             ok += 1
         if n % 100 == 0:
             print("   %d/%d" % (n, len(todo)))
-        if backups_before and n % 25 == 0:
+        if prune and n % 25 == 0:
             _prune_backups(backups_before)
-    if backups_before:
+    if prune:
         _prune_backups(backups_before)
     print("\nRewrote %d, failed %d." % (ok, fail))
 

--- a/skills/dayone-import/scripts/dayone-import.py
+++ b/skills/dayone-import/scripts/dayone-import.py
@@ -426,9 +426,17 @@ def _fmt_signature(rtf):
     return tuple(len(pat.findall(rtf)) for _name, pat in _FMT_CONTROLS)
 
 
-def _render(cli, md, plain=False):
-    """What journal-cli --markdown would store for this source, or None."""
-    cmd = [cli, "render"] + (["--plain"] if plain else [])
+def _render(cli, md, plain=False, inline=False):
+    """What journal-cli --markdown would store for this source, or None.
+
+    `inline` matches how a title is rendered: no block handling, so a title
+    of "1. first" stays a title rather than becoming a list item.
+    """
+    cmd = [cli, "render"]
+    if inline:
+        cmd.append("--inline")
+    elif plain:
+        cmd.append("--plain")
     r = subprocess.run(cmd, input=(md or "").encode("utf-8"),
                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     return None if r.returncode else r.stdout
@@ -466,7 +474,7 @@ def cmd_fix_text(args):
         why = None
 
         want_title = _render(args.cli, e.get("title_md") or e["title"] or "",
-                             plain=True)
+                             inline=True)
         if want_title is not None and want_title.decode("utf-8", "replace") != title:
             why = "title differs from rendered source"
 

--- a/skills/dayone-import/scripts/dayone-import.py
+++ b/skills/dayone-import/scripts/dayone-import.py
@@ -364,14 +364,21 @@ def cmd_fix_locations(args):
     print("\nRelocated %d of %d." % (ok, len(fixes)))
 
 
+# Syntax the renderer strips. If any of it is still visible in the stored
+# plain text, that entry was never rendered. Underscore forms carry flanking
+# rules so identifiers like foo__bar__baz are not mistaken for emphasis.
 ARTIFACTS = [
-    re.compile(r"(?m)^[ \t]{0,3}#{1,6}[ \t]+"),          # ###### heading
-    re.compile(r"\\[\\`*_{}\[\]()#+\-.!>~|]"),           # \. \- escaping
-    re.compile(r"(?m)^[ \t]*(?:-{3,}|\*{3,})[ \t]*$"),   # --- rule
-    re.compile(r"\*\*\S.*?\S\*\*"),                       # **bold**
-    re.compile(r"\[[^\]]+\]\([^)\s]+\)"),                 # [text](url)
+    re.compile(r"(?m)^[ \t]{0,3}#{1,6}[ \t]+"),              # ###### heading
+    re.compile(r"\\[\\`*_{}\[\]()#+\-.!>~|]"),               # \. \- escaping
+    re.compile(r"(?m)^[ \t]*(?:-{3,}|\*{3,}|_{3,})[ \t]*$"),  # --- *** ___ rule
+    re.compile(r"(?m)^[ \t]*```"),                           # fenced code
+    re.compile(r"(?m)^[ \t]{0,3}>[ \t]?\S"),                  # > blockquote
+    re.compile(r"\*\*\S.*?\S\*\*"),                            # **bold**
+    re.compile(r"(?<![\w_])__(?=\S).+?(?<=\S)__(?![\w_])"),   # __bold__
+    re.compile(r"(?<![\w_])_(?=\S)[^_\n]+?(?<=\S)_(?![\w_])"),  # _italic_
+    re.compile(r"~~\S.*?\S~~"),                              # ~~struck~~
+    re.compile(r"\[[^\]]+\]\([^)\s]+\)"),                      # [text](url)
 ]
-
 
 # A backslash escape and the character it protects, replaced wholesale before
 # looking for formatting so the escaped delimiter cannot match.
@@ -379,9 +386,11 @@ ESCAPED_PAIR = re.compile(r"\\.", re.S)
 
 # Constructs in the Day One source that must survive as real formatting.
 SOURCE_FEATURES = {
-    "bold": re.compile(r"(?m)^[ \t]{0,3}#{1,6}[ \t]+\S|\*\*\S.*?\S\*\*"),
+    "bold": re.compile(r"(?m)^[ \t]{0,3}#{1,6}[ \t]+\S|\*\*\S.*?\S\*\*"
+                       r"|(?<![\w_])__(?=\S).+?(?<=\S)__(?![\w_])"),
     "list": re.compile(r"(?m)^[ \t]{0,3}(?:[-*+]|[0-9]{1,9}[.)])[ \t]+\S"),
-    "italic": re.compile(r"(?<![\w*])\*(?=\S)[^*\n]+?(?<=\S)\*(?![\w*])"),
+    "italic": re.compile(r"(?<![\w*])\*(?=\S)[^*\n]+?(?<=\S)\*(?![\w*])"
+                         r"|(?<![\w_])_(?=\S)[^_\n]+?(?<=\S)_(?![\w_])"),
     "strike": re.compile(r"~~\S.*?\S~~"),
 }
 # ...and the RTF markup each one produces.
@@ -411,7 +420,7 @@ def _stored(cli, target_db):
 
     db = target_db or os.path.expanduser(
         "~/Library/Group Containers/group.com.apple.moments/Library/moments.sqlite")
-    rtf = {}
+    rtf, rtf_ok = {}, True
     try:
         con = sqlite3.connect("file:%s?mode=ro" % db, uri=True)
         for pk, blob in con.execute(
@@ -420,8 +429,13 @@ def _stored(cli, target_db):
                        if isinstance(blob, (bytes, bytearray)) else str(blob))
         con.close()
     except sqlite3.Error:
-        pass                       # fall back to plain-text checks only
-    return {pk: (t[0], t[1], rtf.get(pk, "")) for pk, t in text.items()}
+        # Without the RTF we cannot tell rendered from unrendered formatting.
+        # Say so and check only what plain text can prove, rather than
+        # treating every entry as having lost its markup.
+        rtf_ok = False
+        sys.stderr.write("note: could not read entry RTF from %s; checking "
+                         "visible text only.\n" % db)
+    return ({pk: (t[0], t[1], rtf.get(pk, "")) for pk, t in text.items()}, rtf_ok)
 
 
 def cmd_fix_text(args):
@@ -438,7 +452,7 @@ def cmd_fix_text(args):
     if not state["done"]:
         die("no import state at %s -- run `import` first" % state_path)
 
-    stored = _stored(args.cli, args.target_db)
+    stored, rtf_ok = _stored(args.cli, args.target_db)
     todo, reasons = [], collections.Counter()
     for e in entries:
         pk = state["done"].get(e["uuid"])
@@ -448,7 +462,7 @@ def cmd_fix_text(args):
         why = None
         if any(p.search(title + "\n" + text) for p in ARTIFACTS):
             why = "raw markdown visible"
-        else:
+        elif rtf_ok:
             # Only the body is stored as RTF; the title is a separate plain
             # field. Comparing title markup against the body's RTF would
             # never match and would rewrite the entry on every run.

--- a/skills/dayone-import/scripts/dayone-import.py
+++ b/skills/dayone-import/scripts/dayone-import.py
@@ -293,7 +293,7 @@ def cmd_fix_locations(args):
     fixes, skipped_unverified = [], []
     for e in entries:
         pk = state["done"].get(e["uuid"])
-        if not isinstance(pk, int):
+        if type(pk) is not int:
             continue
         got = _photo_fix(e)
         if not got:
@@ -483,7 +483,9 @@ def cmd_fix_text(args):
     todo, reasons, edited = [], collections.Counter(), []
     for e in entries:
         pk = state["done"].get(e["uuid"])
-        if not isinstance(pk, int) or pk not in stored:
+        # `True` is an int in Python and equal to 1, so a state record that
+        # fell back to a boolean would otherwise target entry 1.
+        if type(pk) is not int or pk not in stored:
             continue
         title, text, rtf = stored[pk]
         # An entry edited in Journal since import carries Journal's own CRDT

--- a/skills/dayone-import/scripts/dayone-import.py
+++ b/skills/dayone-import/scripts/dayone-import.py
@@ -5,7 +5,6 @@ Subcommands:
   journals                       list Day One journals and entry counts
   plan     <journal>             what would be imported, and what can't be
   import   <journal>             write the entries via journal-cli
-  fix-locations <journal>        correct imported locations from photo EXIF
   fix-export <journal> <dir>     repair a Day One markdown export in place
 
 Why this exists: Day One's markdown export silently renders every timestamp
@@ -14,7 +13,7 @@ hours -- sometimes a whole day -- off. Day One's SQLite store still has the
 original zone per entry, so this reads that directly and uses the export
 folder only as a source of image bytes.
 """
-import os, re, sys, json, shutil, argparse, subprocess, datetime
+import os, re, sys, json, shutil, sqlite3, argparse, collections, subprocess, datetime
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import dayone, exifgps, photoslib
@@ -141,10 +140,15 @@ def cmd_import(args):
         cmd += ["write", "--journal", target]
         when = e["utc"] if args.time_mode == "utc" else e["local"]
         cmd += ["--date", when]
+        # Hand over the raw markdown: journal-cli --markdown renders it into
+        # Journal's rich text, so headings and emphasis become real formatting
+        # instead of literal "###### " in the finished entry.
         if e["title"]:
-            cmd += ["--title", e["title"]]
+            cmd += ["--title", e.get("title_md") or e["title"]]
         if e["body"]:
-            cmd += ["--body", e["body"]]
+            cmd += ["--body", e.get("body_md") or e["body"]]
+        if e["title"] or e["body"]:
+            cmd += ["--markdown"]
         if e["starred"]:
             cmd += ["--bookmark"]
         if e["lat"] is not None and e["lon"] is not None:
@@ -352,6 +356,146 @@ def cmd_fix_locations(args):
         else:
             ok += 1
     print("\nRelocated %d of %d." % (ok, len(fixes)))
+
+
+ARTIFACTS = [
+    re.compile(r"(?m)^[ \t]{0,3}#{1,6}[ \t]+"),          # ###### heading
+    re.compile(r"\\[\\`*_{}\[\]()#+\-.!>~|]"),           # \. \- escaping
+    re.compile(r"(?m)^[ \t]*(?:-{3,}|\*{3,})[ \t]*$"),   # --- rule
+    re.compile(r"\*\*\S.*?\S\*\*"),                       # **bold**
+    re.compile(r"\[[^\]]+\]\([^)\s]+\)"),                 # [text](url)
+]
+
+
+# Constructs in the Day One source that must survive as real formatting.
+SOURCE_FEATURES = {
+    "bold": re.compile(r"(?m)^[ \t]{0,3}#{1,6}[ \t]+\S|\*\*\S.*?\S\*\*"),
+    "list": re.compile(r"(?m)^[ \t]{0,3}(?:[-*+]|[0-9]{1,9}[.)])[ \t]+\S"),
+    "italic": re.compile(r"(?<![\w*])\*(?=\S)[^*\n]+?(?<=\S)\*(?![\w*])"),
+    "strike": re.compile(r"~~\S.*?\S~~"),
+}
+# ...and the RTF markup each one produces.
+RTF_MARKERS = {
+    "bold": "Bold",
+    "list": "listtext",
+    "italic": "\\i ",
+    "strike": "\\strike",
+}
+
+
+def _stored(cli, target_db):
+    """pk -> (title, plain text, raw RTF) for entries currently in the store.
+
+    The RTF matters: an entry can read correctly as plain text while still
+    having lost the bold and list markup its source called for.
+    """
+    cmd = [cli]
+    if target_db:
+        cmd += ["--db", target_db]
+    cmd += ["list", "--limit", "100000", "--full", "--include-empty", "--json"]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode:
+        die("could not list entries: %s" % r.stderr.strip())
+    text = {e["id"]: (e.get("title") or "", e.get("text") or "")
+            for e in json.loads(r.stdout)}
+
+    db = target_db or os.path.expanduser(
+        "~/Library/Group Containers/group.com.apple.moments/Library/moments.sqlite")
+    rtf = {}
+    try:
+        con = sqlite3.connect("file:%s?mode=ro" % db, uri=True)
+        for pk, blob in con.execute(
+                "select Z_PK, ZTEXT from ZJOURNALENTRYMO where ZTEXT is not null"):
+            rtf[pk] = (blob.decode("utf-8", "replace")
+                       if isinstance(blob, (bytes, bytearray)) else str(blob))
+        con.close()
+    except sqlite3.Error:
+        pass                       # fall back to plain-text checks only
+    return {pk: (t[0], t[1], rtf.get(pk, "")) for pk, t in text.items()}
+
+
+def cmd_fix_text(args):
+    """Re-render entries whose text still carries raw Markdown syntax.
+
+    Early imports wrote Day One's markdown through as plain text, so headings
+    and escapes ended up visible. This rewrites those entries from the
+    original markdown using journal-cli --markdown.
+    """
+    j, entries = gather(args)
+    state_path = args.state or os.path.join(
+        STATE_DIR, re.sub(r"\W+", "_", j["name"]) + ".json")
+    state = load_state(state_path)
+    if not state["done"]:
+        die("no import state at %s -- run `import` first" % state_path)
+
+    stored = _stored(args.cli, args.target_db)
+    todo, reasons = [], collections.Counter()
+    for e in entries:
+        pk = state["done"].get(e["uuid"])
+        if not isinstance(pk, int) or pk not in stored:
+            continue
+        title, text, rtf = stored[pk]
+        why = None
+        if any(p.search(title + "\n" + text) for p in ARTIFACTS):
+            why = "raw markdown visible"
+        else:
+            source = (e.get("title_md") or "") + "\n" + (e.get("body_md") or "")
+            for name, pat in SOURCE_FEATURES.items():
+                if pat.search(source) and RTF_MARKERS[name] not in rtf:
+                    why = "lost %s formatting" % name
+                    break
+        if why:
+            reasons[why] += 1
+            todo.append((e, pk))
+
+    print("%d of %d imported entries need re-rendering."
+          % (len(todo), len(state["done"])))
+    for why, n in reasons.most_common():
+        print("   %4d  %s" % (n, why))
+    if not todo:
+        return
+    for e, pk in todo[:5]:
+        before = stored[pk][1].split("\n")[0][:64]
+        print("   [%s] %s" % (pk, before or stored[pk][0][:64]))
+    if len(todo) > 5:
+        print("   ... and %d more" % (len(todo) - 5))
+    if args.dry_run:
+        print("\nDRY RUN: nothing written.")
+        return
+
+    ok = fail = 0
+    for n, (e, pk) in enumerate(todo, 1):
+        cmd = [args.cli]
+        if args.target_db:
+            cmd += ["--db", args.target_db]
+        cmd += ["edit", str(pk), "--markdown"]
+        title_md = e.get("title_md") or e["title"]
+        # Drive off the raw markdown, not the rendered text: a body that is
+        # only a "---" rule renders to nothing and must be cleared, which a
+        # truthiness check on the rendered text would skip.
+        body_md = e.get("body_md")
+        if body_md is None:
+            body_md = e["body"]
+        if title_md:
+            cmd += ["--title", title_md]
+        if body_md is not None and (body_md != "" or e["body"] == ""):
+            cmd += ["--body", body_md]
+        if not title_md and not body_md:
+            continue
+        if not args.target_db:
+            cmd += ["--live", "--accept-risk"]
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        if r.returncode:
+            fail += 1
+            sys.stderr.write("  entry %s FAILED: %s\n"
+                             % (pk, (r.stderr or r.stdout).strip().split("\n")[-1]))
+            if fail >= args.max_failures:
+                die("stopping after %d failures" % fail)
+        else:
+            ok += 1
+        if n % 100 == 0:
+            print("   %d/%d" % (n, len(todo)))
+    print("\nRewrote %d, failed %d." % (ok, fail))
 
 
 # ------------------------------------------------------------- fix-export
@@ -586,6 +730,17 @@ def main():
                         "library has no matching asset to corroborate them")
     s.add_argument("--dry-run", action="store_true")
     s.set_defaults(func=cmd_fix_locations)
+
+    s = sub.add_parser("fix-text",
+                       help="re-render imported entries that still show raw Markdown")
+    s.add_argument("journal")
+    s.add_argument("--export", help="markdown export dir (extra media source)")
+    s.add_argument("--target-db", help="operate on a sandbox store instead")
+    s.add_argument("--cli", default="journal-cli")
+    s.add_argument("--state", help="import state file to map entries by")
+    s.add_argument("--max-failures", type=int, default=5)
+    s.add_argument("--dry-run", action="store_true")
+    s.set_defaults(func=cmd_fix_text)
 
     s = sub.add_parser("fix-export",
                        help="repair timestamps in a Day One markdown export")

--- a/skills/dayone-import/scripts/dayone-import.py
+++ b/skills/dayone-import/scripts/dayone-import.py
@@ -364,44 +364,6 @@ def cmd_fix_locations(args):
     print("\nRelocated %d of %d." % (ok, len(fixes)))
 
 
-# Syntax the renderer strips. If any of it is still visible in the stored
-# plain text, that entry was never rendered. Underscore forms carry flanking
-# rules so identifiers like foo__bar__baz are not mistaken for emphasis.
-ARTIFACTS = [
-    re.compile(r"(?m)^[ \t]{0,3}#{1,6}[ \t]+"),              # ###### heading
-    re.compile(r"\\[\\`*_{}\[\]()#+\-.!>~|]"),               # \. \- escaping
-    re.compile(r"(?m)^[ \t]*(?:-{3,}|\*{3,}|_{3,})[ \t]*$"),  # --- *** ___ rule
-    re.compile(r"(?m)^[ \t]*```"),                           # fenced code
-    re.compile(r"(?m)^[ \t]{0,3}>[ \t]?\S"),                  # > blockquote
-    re.compile(r"\*\*\S.*?\S\*\*"),                            # **bold**
-    re.compile(r"(?<![\w_])__(?=\S).+?(?<=\S)__(?![\w_])"),   # __bold__
-    re.compile(r"(?<![\w_])_(?=\S)[^_\n]+?(?<=\S)_(?![\w_])"),  # _italic_
-    re.compile(r"~~\S.*?\S~~"),                              # ~~struck~~
-    re.compile(r"\[[^\]]+\]\([^)\s]+\)"),                      # [text](url)
-]
-
-# A backslash escape and the character it protects, replaced wholesale before
-# looking for formatting so the escaped delimiter cannot match.
-ESCAPED_PAIR = re.compile(r"\\.", re.S)
-
-# Constructs in the Day One source that must survive as real formatting.
-SOURCE_FEATURES = {
-    "bold": re.compile(r"(?m)^[ \t]{0,3}#{1,6}[ \t]+\S|\*\*\S.*?\S\*\*"
-                       r"|(?<![\w_])__(?=\S).+?(?<=\S)__(?![\w_])"),
-    "list": re.compile(r"(?m)^[ \t]{0,3}(?:[-*+]|[0-9]{1,9}[.)])[ \t]+\S"),
-    "italic": re.compile(r"(?<![\w*])\*(?=\S)[^*\n]+?(?<=\S)\*(?![\w*])"
-                         r"|(?<![\w_])_(?=\S)[^_\n]+?(?<=\S)_(?![\w_])"),
-    "strike": re.compile(r"~~\S.*?\S~~"),
-}
-# ...and the RTF markup each one produces.
-RTF_MARKERS = {
-    "bold": "Bold",
-    "list": "listtext",
-    "italic": "\\i ",
-    "strike": "\\strike",
-}
-
-
 def _stored(cli, target_db):
     """pk -> (title, plain text, raw RTF) for entries currently in the store.
 
@@ -425,8 +387,8 @@ def _stored(cli, target_db):
         con = sqlite3.connect("file:%s?mode=ro" % db, uri=True)
         for pk, blob in con.execute(
                 "select Z_PK, ZTEXT from ZJOURNALENTRYMO where ZTEXT is not null"):
-            rtf[pk] = (blob.decode("utf-8", "replace")
-                       if isinstance(blob, (bytes, bytearray)) else str(blob))
+            rtf[pk] = (bytes(blob) if isinstance(blob, (bytes, bytearray))
+                       else str(blob).encode("utf-8"))
         con.close()
     except sqlite3.Error:
         # Without the RTF we cannot tell rendered from unrendered formatting.
@@ -435,7 +397,15 @@ def _stored(cli, target_db):
         rtf_ok = False
         sys.stderr.write("note: could not read entry RTF from %s; checking "
                          "visible text only.\n" % db)
-    return ({pk: (t[0], t[1], rtf.get(pk, "")) for pk, t in text.items()}, rtf_ok)
+    return ({pk: (t[0], t[1], rtf.get(pk)) for pk, t in text.items()}, rtf_ok)
+
+
+def _render(cli, md, plain=False):
+    """What journal-cli --markdown would store for this source, or None."""
+    cmd = [cli, "render"] + (["--plain"] if plain else [])
+    r = subprocess.run(cmd, input=(md or "").encode("utf-8"),
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return None if r.returncode else r.stdout
 
 
 def cmd_fix_text(args):
@@ -453,6 +423,14 @@ def cmd_fix_text(args):
         die("no import state at %s -- run `import` first" % state_path)
 
     stored, rtf_ok = _stored(args.cli, args.target_db)
+    if _render(args.cli, "probe") is None:
+        die("%s has no `render` command -- upgrade journal-cli" % args.cli)
+
+    # Compare each entry against what the renderer would produce now, rather
+    # than sniffing the stored text for leftover syntax. Sniffing cannot tell
+    # a correctly rendered "**literal**" (from escaped source) or a fenced
+    # "# comment" from unrendered markup, so it kept flagging good entries
+    # forever. An exact comparison is idempotent by construction.
     todo, reasons = [], collections.Counter()
     for e in entries:
         pk = state["done"].get(e["uuid"])
@@ -460,20 +438,31 @@ def cmd_fix_text(args):
             continue
         title, text, rtf = stored[pk]
         why = None
-        if any(p.search(title + "\n" + text) for p in ARTIFACTS):
-            why = "raw markdown visible"
-        elif rtf_ok:
-            # Only the body is stored as RTF; the title is a separate plain
-            # field. Comparing title markup against the body's RTF would
-            # never match and would rewrite the entry on every run.
-            # Neutralize backslash-escaped characters first: "\\*literal\\*"
-            # is not emphasis, and matching it here would report lost
-            # formatting and rewrite the same entry on every run.
-            source = ESCAPED_PAIR.sub("x", e.get("body_md") or "")
-            for name, pat in SOURCE_FEATURES.items():
-                if pat.search(source) and RTF_MARKERS[name] not in rtf:
-                    why = "lost %s formatting" % name
-                    break
+
+        want_title = _render(args.cli, e.get("title_md") or e["title"] or "",
+                             plain=True)
+        if want_title is not None and want_title.decode("utf-8", "replace") != title:
+            why = "title differs from rendered source"
+
+        body_md = e.get("body_md")
+        if body_md is None:
+            body_md = e["body"] or ""
+        if why is None and rtf_ok:
+            want = _render(args.cli, body_md)
+            want_plain = _render(args.cli, body_md, plain=True) or b""
+            if want is None:
+                pass
+            elif not want_plain.strip():
+                if rtf is not None:
+                    why = "body should be empty"
+            elif rtf != want:
+                why = "body differs from rendered source"
+        elif why is None:
+            want_plain = _render(args.cli, body_md, plain=True)
+            if want_plain is not None and \
+                    want_plain.decode("utf-8", "replace") != text:
+                why = "body text differs from rendered source"
+
         if why:
             reasons[why] += 1
             todo.append((e, pk))

--- a/skills/dayone-import/scripts/dayone-import.py
+++ b/skills/dayone-import/scripts/dayone-import.py
@@ -122,6 +122,13 @@ def cmd_import(args):
     if args.limit:
         todo = todo[:args.limit]
 
+    # Probe once rather than discovering mid-migration: an older journal-cli
+    # rejects --markdown for every text entry while media-only entries still
+    # land, leaving a half-written journal and state file.
+    if _render(args.cli, "probe") is None:
+        die("%s does not support --markdown (needs journal-cli 1.1.0+)"
+            % args.cli)
+
     live = not args.target_db
     print("Day One '%s' -> Apple Journal '%s'" % (j["name"], target))
     print("%d to write, %d already done, %d empty/skipped%s"
@@ -380,7 +387,9 @@ def _stored(cli, target_db):
     text = {e["id"]: (e.get("title") or "", e.get("text") or "")
             for e in json.loads(r.stdout)}
 
-    db = target_db or os.path.expanduser(
+    # Must be the same store the `list` subprocess just read, or primary keys
+    # would be matched against a different database entirely.
+    db = target_db or os.environ.get("JOURNAL_DB") or os.path.expanduser(
         "~/Library/Group Containers/group.com.apple.moments/Library/moments.sqlite")
     rtf, rtf_ok = {}, True
     try:
@@ -398,6 +407,23 @@ def _stored(cli, target_db):
         sys.stderr.write("note: could not read entry RTF from %s; checking "
                          "visible text only.\n" % db)
     return ({pk: (t[0], t[1], rtf.get(pk)) for pk, t in text.items()}, rtf_ok)
+
+
+# Formatting controls that carry meaning, counted so two RTF documents can be
+# compared without tripping over serializer differences -- a macOS upgrade can
+# change the \cocoartf version or font-table order without changing a word.
+_FMT_CONTROLS = (
+    ("bold", re.compile(rb"\\b(?![0-9a-zA-Z])")),
+    ("italic", re.compile(rb"\\i(?![0-9a-zA-Z])")),
+    ("strike", re.compile(rb"\\strike(?![0-9a-zA-Z])")),
+    ("list", re.compile(rb"\\listtext")),
+)
+
+
+def _fmt_signature(rtf):
+    if rtf is None:
+        return None
+    return tuple(len(pat.findall(rtf)) for _name, pat in _FMT_CONTROLS)
 
 
 def _render(cli, md, plain=False):
@@ -447,21 +473,19 @@ def cmd_fix_text(args):
         body_md = e.get("body_md")
         if body_md is None:
             body_md = e["body"] or ""
-        if why is None and rtf_ok:
-            want = _render(args.cli, body_md)
-            want_plain = _render(args.cli, body_md, plain=True) or b""
-            if want is None:
-                pass
-            elif not want_plain.strip():
-                if rtf is not None:
-                    why = "body should be empty"
-            elif rtf != want:
-                why = "body differs from rendered source"
-        elif why is None:
+        if why is None:
             want_plain = _render(args.cli, body_md, plain=True)
-            if want_plain is not None and \
-                    want_plain.decode("utf-8", "replace") != text:
+            want_text = ("" if want_plain is None
+                         else want_plain.decode("utf-8", "replace"))
+            if want_plain is not None and want_text != text:
                 why = "body text differs from rendered source"
+            elif rtf_ok and want_plain is not None:
+                if not want_text.strip():
+                    if rtf is not None:
+                        why = "body should be empty"
+                elif _fmt_signature(rtf) != _fmt_signature(
+                        _render(args.cli, body_md)):
+                    why = "body formatting differs from rendered source"
 
         if why:
             reasons[why] += 1

--- a/skills/dayone-import/scripts/dayone-import.py
+++ b/skills/dayone-import/scripts/dayone-import.py
@@ -337,7 +337,9 @@ def cmd_fix_locations(args):
         return
 
     ok = 0
-    for e, pk, got, off, place, city in fixes:
+    backups_before = (set(_backup_dirs())
+                      if not args.target_db and args.prune_backups else set())
+    for n, (e, pk, got, off, place, city) in enumerate(fixes, 1):
         cmd = [args.cli]
         if args.target_db:
             cmd += ["--db", args.target_db]
@@ -355,6 +357,10 @@ def cmd_fix_locations(args):
                              % (pk, (r.stderr or r.stdout).strip().split("\n")[-1]))
         else:
             ok += 1
+        if backups_before and n % 25 == 0:
+            _prune_backups(backups_before)
+    if backups_before:
+        _prune_backups(backups_before)
     print("\nRelocated %d of %d." % (ok, len(fixes)))
 
 
@@ -439,7 +445,10 @@ def cmd_fix_text(args):
         if any(p.search(title + "\n" + text) for p in ARTIFACTS):
             why = "raw markdown visible"
         else:
-            source = (e.get("title_md") or "") + "\n" + (e.get("body_md") or "")
+            # Only the body is stored as RTF; the title is a separate plain
+            # field. Comparing title markup against the body's RTF would
+            # never match and would rewrite the entry on every run.
+            source = e.get("body_md") or ""
             for name, pat in SOURCE_FEATURES.items():
                 if pat.search(source) and RTF_MARKERS[name] not in rtf:
                     why = "lost %s formatting" % name
@@ -464,6 +473,8 @@ def cmd_fix_text(args):
         return
 
     ok = fail = 0
+    backups_before = (set(_backup_dirs())
+                      if not args.target_db and args.prune_backups else set())
     for n, (e, pk) in enumerate(todo, 1):
         cmd = [args.cli]
         if args.target_db:
@@ -495,6 +506,10 @@ def cmd_fix_text(args):
             ok += 1
         if n % 100 == 0:
             print("   %d/%d" % (n, len(todo)))
+        if backups_before and n % 25 == 0:
+            _prune_backups(backups_before)
+    if backups_before:
+        _prune_backups(backups_before)
     print("\nRewrote %d, failed %d." % (ok, fail))
 
 
@@ -728,6 +743,8 @@ def main():
     s.add_argument("--trust-exif", action="store_true",
                    help="override existing locations even when the Photos "
                         "library has no matching asset to corroborate them")
+    s.add_argument("--prune-backups", action="store_true",
+                   help="trash the per-write store snapshots as they pile up")
     s.add_argument("--dry-run", action="store_true")
     s.set_defaults(func=cmd_fix_locations)
 
@@ -739,6 +756,8 @@ def main():
     s.add_argument("--cli", default="journal-cli")
     s.add_argument("--state", help="import state file to map entries by")
     s.add_argument("--max-failures", type=int, default=5)
+    s.add_argument("--prune-backups", action="store_true",
+                   help="trash the per-write store snapshots as they pile up")
     s.add_argument("--dry-run", action="store_true")
     s.set_defaults(func=cmd_fix_text)
 

--- a/skills/dayone-import/scripts/dayone.py
+++ b/skills/dayone-import/scripts/dayone.py
@@ -96,6 +96,33 @@ def timezone_name(blob):
     return m.group(1).decode("utf-8", "replace") if m else None
 
 
+# Day One writes markdown; Apple Journal stores plain text and renders none
+# of it, so any syntax left in place shows up literally as "###### " and
+# "\\." in the finished entry.
+_ESCAPED = re.compile(r"\\([\\`*_{}\[\]()#+\-.!>~|])")
+_HEADING = re.compile(r"(?m)^[ \t]{0,3}#{1,6}[ \t]+")
+_RULE = re.compile(r"(?m)^[ \t]*(?:-{3,}|\*{3,}|_{3,})[ \t]*$")
+_BOLD_ITALIC = re.compile(r"(\*{1,3}|_{1,3})(\S(?:.*?\S)?)\1", re.S)
+_LINK = re.compile(r'\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)')
+_CODE_FENCE = re.compile(r"(?m)^[ \t]*```[^\n]*$")
+
+
+def markdown_to_text(md):
+    """Flatten Day One markdown into what a plain-text reader should see."""
+    if not md:
+        return md
+    out = _CODE_FENCE.sub("", md)
+    out = _RULE.sub("", out)
+    out = _HEADING.sub("", out)
+    # a link becomes "text (url)", or just the url when the text repeats it
+    out = _LINK.sub(lambda m: m.group(2) if m.group(1).strip() in ("", m.group(2))
+                    else "%s (%s)" % (m.group(1), m.group(2)), out)
+    out = _BOLD_ITALIC.sub(lambda m: m.group(2), out)
+    out = _ESCAPED.sub(r"\1", out)
+    out = re.sub(r"\n{3,}", "\n\n", out)
+    return out.strip()
+
+
 def _local(utc, tz):
     if tz and zoneinfo:
         try:
@@ -185,6 +212,12 @@ def read_entries(con, journal_pk, media=None):
                 body = "\n".join(lines[1:]).strip()
             else:
                 title, body = first, "\n".join(lines[1:]).strip()
+        # Keep the raw markdown too: journal-cli --markdown renders it into
+        # Journal's rich text, so headings survive as real bold rather than
+        # being flattened here.
+        title_md, body_md = title, body
+        title = markdown_to_text(title) or None
+        body = markdown_to_text(body)
 
         tz = timezone_name(e["ZTIMEZONE"])
         utc = datetime.datetime.fromtimestamp(
@@ -203,6 +236,8 @@ def read_entries(con, journal_pk, media=None):
             "starred": bool(e["ZSTARRED"]),
             "title": title,
             "body": body,
+            "title_md": title_md,
+            "body_md": body_md,
             "media": files,
             "audio": audio,
             "missing": missing,

--- a/skills/dayone-import/scripts/dayone.py
+++ b/skills/dayone-import/scripts/dayone.py
@@ -107,6 +107,22 @@ _LINK = re.compile(r'\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)')
 _CODE_FENCE = re.compile(r"(?m)^[ \t]*```[^\n]*$")
 
 
+def markdown_to_inline_text(md):
+    """Flatten a single-line field such as a title.
+
+    Block rules must not apply: a first line of "---" is a title, not a
+    horizontal rule, and "1. first" is a title, not a list item. Mirrors
+    journal-cli's `render --inline`.
+    """
+    if not md:
+        return md
+    out = _LINK.sub(lambda m: m.group(2) if m.group(1).strip() in ("", m.group(2))
+                    else "%s (%s)" % (m.group(1), m.group(2)), md)
+    out = _BOLD_ITALIC.sub(lambda m: m.group(2), out)
+    out = _ESCAPED.sub(r"\1", out)
+    return out.strip()
+
+
 def markdown_to_text(md):
     """Flatten Day One markdown into what a plain-text reader should see."""
     if not md:
@@ -216,7 +232,7 @@ def read_entries(con, journal_pk, media=None):
         # Journal's rich text, so headings survive as real bold rather than
         # being flattened here.
         title_md, body_md = title, body
-        title = markdown_to_text(title) or None
+        title = markdown_to_inline_text(title) or None
         body = markdown_to_text(body)
 
         tz = timezone_name(e["ZTIMEZONE"])

--- a/skills/journal-cli/SKILL.md
+++ b/skills/journal-cli/SKILL.md
@@ -49,6 +49,7 @@ journal-cli write --live --lat N --lon N --place P --city C
 journal-cli write --live --link URL --link-title T
 journal-cli write --live --journal "Name" ...          # non-default journal
 journal-cli edit <id> --live [same flags; --add-media/--add-link/--remove-media ID/--clear-location/--journal N]
+journal-cli sync-journals --live                       # repair pre-1.0.7 cross-device memberships
 journal-cli delete <id> --live                         # soft; syncs properly
 journal-cli restore <id> --live
 ```
@@ -88,5 +89,9 @@ for anything experimental; replay with `--live` once it looks right.
   entries — it propagates.
 - If the user has a designated test journal, write there
   (`--journal "<name>"`); check `journal-cli journals --json` first.
+- If custom-journal entries look correct on the Mac but appear in the default
+  Journal on another device, run `sync-journals --dry-run` and then
+  `sync-journals --live`. This queues each custom journal record for re-upload;
+  it does not rewrite every entry.
 - Dates print in the machine's local timezone; a stale or invalid `TZ` env
   var in your shell will skew displayed times, not stored ones.

--- a/swift/Sources/journal-cli/Markdown.swift
+++ b/swift/Sources/journal-cli/Markdown.swift
@@ -44,15 +44,29 @@ private let EMPH = rx("(?<![\\w*_])([*_])(?=\\S)([^*_]+?)(?<=\\S)\\1(?![\\w*_])"
 // italics -- so each one is swapped for a private-use codepoint before the
 // emphasis regexes run and swapped back afterwards.
 private let ESCAPABLE = Array("\\`*_{}[]()#+-.!>~|")
-private let ESCAPE_BASE: UInt32 = 0xE000
 
-private func protectEscapes(_ s: String) -> String {
+/// Pick a private-use window this text does not already use, so a literal
+/// U+E000 in someone's entry is never mistaken for our own sentinel and
+/// rewritten as punctuation.
+private func escapeBase(for s: String) -> UInt32 {
+    let width = UInt32(ESCAPABLE.count)
+    let used = Set(s.unicodeScalars.map { $0.value }.filter { $0 >= 0xE000 && $0 <= 0xF8FF })
+    if used.isEmpty { return 0xE000 }
+    var base: UInt32 = 0xE000
+    while base + width <= 0xF8FF {
+        if !(base..<(base + width)).contains(where: { used.contains($0) }) { return base }
+        base += width
+    }
+    return 0xE000
+}
+
+private func protectEscapes(_ s: String, _ base: UInt32) -> String {
     var out = ""
     var escaping = false
     for ch in s {
         if escaping {
             if let i = ESCAPABLE.firstIndex(of: ch),
-               let scalar = Unicode.Scalar(ESCAPE_BASE + UInt32(i)) {
+               let scalar = Unicode.Scalar(base + UInt32(i)) {
                 out.unicodeScalars.append(scalar)
             } else {
                 out.append("\\")
@@ -74,14 +88,14 @@ private func protectEscapes(_ s: String) -> String {
 /// asterisks rather than turning "literal" bold. Mapping the span's
 /// delimiters onto the same private-use range hides them from the emphasis
 /// regexes, and restoreEscapes puts them back untouched.
-private func protectCodeSpans(_ s: String) -> String {
+private func protectCodeSpans(_ s: String, _ base: UInt32) -> String {
     guard s.contains("`") else { return s }
     var out = ""
     var span: String? = nil
     for ch in s {
         if ch == "`" {
             if let body = span {
-                out.append(hideAll("`" + body + "`"))
+                out.append(hideAll("`" + body + "`", base))
                 span = nil
             } else {
                 span = ""
@@ -97,11 +111,11 @@ private func protectCodeSpans(_ s: String) -> String {
 }
 
 /// Map every escapable character in a string onto the private-use range.
-private func hideAll(_ s: String) -> String {
+private func hideAll(_ s: String, _ base: UInt32) -> String {
     var out = ""
     for ch in s {
         if let i = ESCAPABLE.firstIndex(of: ch),
-           let scalar = Unicode.Scalar(ESCAPE_BASE + UInt32(i)) {
+           let scalar = Unicode.Scalar(base + UInt32(i)) {
             out.unicodeScalars.append(scalar)
         } else {
             out.append(ch)
@@ -110,13 +124,13 @@ private func hideAll(_ s: String) -> String {
     return out
 }
 
-private func restoreEscapes(_ s: String) -> String {
+private func restoreEscapes(_ s: String, _ base: UInt32) -> String {
     var out = ""
     for ch in s {
         let u = ch.unicodeScalars
         if u.count == 1, let v = u.first?.value,
-           v >= ESCAPE_BASE, v < ESCAPE_BASE + UInt32(ESCAPABLE.count) {
-            out.append(ESCAPABLE[Int(v - ESCAPE_BASE)])
+           v >= base, v < base + UInt32(ESCAPABLE.count) {
+            out.append(ESCAPABLE[Int(v - base)])
         } else {
             out.append(ch)
         }
@@ -155,7 +169,8 @@ private enum LineKind: Equatable {
 
 /// Pull inline emphasis out of a line, leaving styled spans behind.
 private func inlineSpans(_ line: String, forceBold: Bool) -> [Span] {
-    var s = protectCodeSpans(protectEscapes(line))
+    let base = escapeBase(for: line)
+    var s = protectCodeSpans(protectEscapes(line, base), base)
 
     // "[text](url)" -> "text (url)", or just the url when the label adds nothing.
     while let m = LINK.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)) {
@@ -179,7 +194,7 @@ private func inlineSpans(_ line: String, forceBold: Bool) -> [Span] {
     var bold = false, italic = false, strike = false
     func flush() {
         if !cur.isEmpty {
-            spans.append(Span(text: restoreEscapes(cur), bold: bold || forceBold,
+            spans.append(Span(text: restoreEscapes(cur, base), bold: bold || forceBold,
                               italic: italic, strike: strike))
             cur = ""
         }
@@ -322,7 +337,11 @@ func markdownToRTF(_ md: String) -> (data: Data, plain: String) {
                           documentAttributes: [:]) else {
         die("could not build RTF from markdown")
     }
-    return (d, att.string)
+    // Round-trip for the plain half: callers use it for ZTEXTLENGTH and for
+    // emptiness, and the attributed string still carries generated list
+    // markers that the stored entry will not show.
+    let plain = NSAttributedString(rtf: d, documentAttributes: nil)?.string ?? att.string
+    return (d, plain)
 }
 
 /// The text as it reads once stored: rendering to RTF and parsing back drops

--- a/swift/Sources/journal-cli/Markdown.swift
+++ b/swift/Sources/journal-cli/Markdown.swift
@@ -36,7 +36,49 @@ private let LINK = rx("\\[([^\\]]*)\\]\\(([^)\\s]+)(?:\\s+\"[^\"]*\")?\\)")
 private let STRONG = rx("(\\*\\*|__)(?=\\S)(.+?)(?<=\\S)\\1")
 private let STRIKE = rx("(~~)(?=\\S)(.+?)(?<=\\S)\\1")
 private let EMPH = rx("(?<![\\w*_])([*_])(?=\\S)([^*_]+?)(?<=\\S)\\1(?![\\w*_])")
-private let ESCAPED = rx("\\\\([\\\\`*_{}\\[\\]()#+\\-.!>~|])")
+// Characters Markdown lets you escape. An escaped delimiter must survive
+// emphasis parsing intact -- "\\*literal\\*" is a literal asterisk pair, not
+// italics -- so each one is swapped for a private-use codepoint before the
+// emphasis regexes run and swapped back afterwards.
+private let ESCAPABLE = Array("\\`*_{}[]()#+-.!>~|")
+private let ESCAPE_BASE: UInt32 = 0xE000
+
+private func protectEscapes(_ s: String) -> String {
+    var out = ""
+    var escaping = false
+    for ch in s {
+        if escaping {
+            if let i = ESCAPABLE.firstIndex(of: ch),
+               let scalar = Unicode.Scalar(ESCAPE_BASE + UInt32(i)) {
+                out.unicodeScalars.append(scalar)
+            } else {
+                out.append("\\")
+                out.append(ch)
+            }
+            escaping = false
+        } else if ch == "\\" {
+            escaping = true
+        } else {
+            out.append(ch)
+        }
+    }
+    if escaping { out.append("\\") }        // a trailing lone backslash
+    return out
+}
+
+private func restoreEscapes(_ s: String) -> String {
+    var out = ""
+    for ch in s {
+        let u = ch.unicodeScalars
+        if u.count == 1, let v = u.first?.value,
+           v >= ESCAPE_BASE, v < ESCAPE_BASE + UInt32(ESCAPABLE.count) {
+            out.append(ESCAPABLE[Int(v - ESCAPE_BASE)])
+        } else {
+            out.append(ch)
+        }
+    }
+    return out
+}
 
 private func sub(_ s: String, _ re: NSRegularExpression, _ tmpl: String) -> String {
     re.stringByReplacingMatches(in: s, range: NSRange(s.startIndex..., in: s),
@@ -69,7 +111,7 @@ private enum LineKind: Equatable {
 
 /// Pull inline emphasis out of a line, leaving styled spans behind.
 private func inlineSpans(_ line: String, forceBold: Bool) -> [Span] {
-    var s = line
+    var s = protectEscapes(line)
 
     // "[text](url)" -> "text (url)", or just the url when the label adds nothing.
     while let m = LINK.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)) {
@@ -86,14 +128,13 @@ private func inlineSpans(_ line: String, forceBold: Bool) -> [Span] {
     s = sub(s, STRONG, "\(B)$2\(B)")
     s = sub(s, STRIKE, "\(S)$2\(S)")
     s = sub(s, EMPH, "\(I)$2\(I)")
-    s = sub(s, ESCAPED, "$1")
 
     var spans: [Span] = []
     var cur = ""
     var bold = false, italic = false, strike = false
     func flush() {
         if !cur.isEmpty {
-            spans.append(Span(text: cur, bold: bold || forceBold,
+            spans.append(Span(text: restoreEscapes(cur), bold: bold || forceBold,
                               italic: italic, strike: strike))
             cur = ""
         }
@@ -141,7 +182,11 @@ func markdownToAttributed(_ md: String) -> NSAttributedString {
     var contents: [[Span]] = []
     var inFence = false
 
-    for raw in md.components(separatedBy: .newlines) {
+    // CRLF must not split twice: .newlines treats \r and \n as separate
+    // delimiters, which would insert a blank line after every source line.
+    let normalized = md.replacingOccurrences(of: "\r\n", with: "\n")
+                       .replacingOccurrences(of: "\r", with: "\n")
+    for raw in normalized.components(separatedBy: "\n") {
         if hits(raw, FENCE) { inFence.toggle(); continue }
         if inFence {
             kinds.append(.body)

--- a/swift/Sources/journal-cli/Markdown.swift
+++ b/swift/Sources/journal-cli/Markdown.swift
@@ -33,7 +33,10 @@ private let BULLET = rx("^[ \\t]{0,3}[-*+][ \\t]+(.*)$")
 private let ORDERED = rx("^[ \\t]{0,3}[0-9]{1,9}[.)][ \\t]+(.*)$")
 private let QUOTE = rx("^[ \\t]{0,3}>[ \\t]?(.*)$")
 private let LINK = rx("\\[([^\\]]*)\\]\\(([^)\\s]+)(?:\\s+\"[^\"]*\")?\\)")
-private let STRONG = rx("(\\*\\*|__)(?=\\S)(.+?)(?<=\\S)\\1")
+private let STRONG_STAR = rx("\\*\\*(?=\\S)(.+?)(?<=\\S)\\*\\*")
+// Underscores need flanking rules that asterisks do not: "foo__bar__baz" is
+// an identifier, not emphasis.
+private let STRONG_UNDER = rx("(?<![\\w_])__(?=\\S)(.+?)(?<=\\S)__(?![\\w_])")
 private let STRIKE = rx("(~~)(?=\\S)(.+?)(?<=\\S)\\1")
 private let EMPH = rx("(?<![\\w*_])([*_])(?=\\S)([^*_]+?)(?<=\\S)\\1(?![\\w*_])")
 // Characters Markdown lets you escape. An escaped delimiter must survive
@@ -125,7 +128,8 @@ private func inlineSpans(_ line: String, forceBold: Bool) -> [Span] {
 
     // Mark emphasis with sentinels so the spans survive unescaping.
     let B = "\u{1}", I = "\u{2}", S = "\u{3}"
-    s = sub(s, STRONG, "\(B)$2\(B)")
+    s = sub(s, STRONG_STAR, "\(B)$1\(B)")
+    s = sub(s, STRONG_UNDER, "\(B)$1\(B)")
     s = sub(s, STRIKE, "\(S)$2\(S)")
     s = sub(s, EMPH, "\(I)$2\(I)")
 

--- a/swift/Sources/journal-cli/Markdown.swift
+++ b/swift/Sources/journal-cli/Markdown.swift
@@ -1,0 +1,242 @@
+// Markdown.swift — render a small Markdown subset into Journal's rich text.
+//
+// Journal stores entry text as RTF and renders formatting, but it does not
+// understand Markdown: syntax left in the text shows up literally, so an
+// imported "###### Reflect on today:" reads as exactly that. This turns the
+// subset that actually appears in journal writing into the formatting
+// Journal itself offers -- bold, italic, strikethrough, and real lists --
+// and strips the rest.
+//
+// Deliberately not a full CommonMark implementation. Tables, images, nested
+// lists, reference links and setext headings are out of scope; anything
+// unrecognized survives as plain text rather than being mangled.
+//
+// Note on escapes: Day One writes "1\. text" when the author meant a literal
+// "1." rather than a numbered list. Because list detection runs against the
+// raw line, before unescaping, those correctly stay plain text.
+import Foundation
+import AppKit
+
+private let BASE_SIZE: CGFloat = 12
+
+private func rx(_ p: String) -> NSRegularExpression {
+    guard let r = try? NSRegularExpression(pattern: p) else {
+        die("bad internal markdown pattern")
+    }
+    return r
+}
+
+private let HEADING = rx("^[ \\t]{0,3}(#{1,6})[ \\t]+(.*)$")
+private let RULE = rx("^[ \\t]*(?:-{3,}|\\*{3,}|_{3,})[ \\t]*$")
+private let FENCE = rx("^[ \\t]*```")
+private let BULLET = rx("^[ \\t]{0,3}[-*+][ \\t]+(.*)$")
+private let ORDERED = rx("^[ \\t]{0,3}[0-9]{1,9}[.)][ \\t]+(.*)$")
+private let QUOTE = rx("^[ \\t]{0,3}>[ \\t]?(.*)$")
+private let LINK = rx("\\[([^\\]]*)\\]\\(([^)\\s]+)(?:\\s+\"[^\"]*\")?\\)")
+private let STRONG = rx("(\\*\\*|__)(?=\\S)(.+?)(?<=\\S)\\1")
+private let STRIKE = rx("(~~)(?=\\S)(.+?)(?<=\\S)\\1")
+private let EMPH = rx("(?<![\\w*_])([*_])(?=\\S)([^*_]+?)(?<=\\S)\\1(?![\\w*_])")
+private let ESCAPED = rx("\\\\([\\\\`*_{}\\[\\]()#+\\-.!>~|])")
+
+private func sub(_ s: String, _ re: NSRegularExpression, _ tmpl: String) -> String {
+    re.stringByReplacingMatches(in: s, range: NSRange(s.startIndex..., in: s),
+                                withTemplate: tmpl)
+}
+
+private func capture(_ s: String, _ re: NSRegularExpression, _ group: Int) -> String? {
+    guard let m = re.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)),
+          let r = Range(m.range(at: group), in: s) else { return nil }
+    return String(s[r])
+}
+
+private func hits(_ s: String, _ re: NSRegularExpression) -> Bool {
+    re.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)) != nil
+}
+
+private struct Span {
+    var text: String
+    var bold = false
+    var italic = false
+    var strike = false
+}
+
+private enum LineKind: Equatable {
+    case body
+    case bullet
+    case ordered
+    case quote
+}
+
+/// Pull inline emphasis out of a line, leaving styled spans behind.
+private func inlineSpans(_ line: String, forceBold: Bool) -> [Span] {
+    var s = line
+
+    // "[text](url)" -> "text (url)", or just the url when the label adds nothing.
+    while let m = LINK.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)) {
+        guard let whole = Range(m.range, in: s) else { break }
+        let label = Range(m.range(at: 1), in: s).map { String(s[$0]) } ?? ""
+        let url = Range(m.range(at: 2), in: s).map { String(s[$0]) } ?? ""
+        let trimmed = label.trimmingCharacters(in: .whitespaces)
+        s.replaceSubrange(whole, with: trimmed.isEmpty || trimmed == url
+                          ? url : "\(trimmed) (\(url))")
+    }
+
+    // Mark emphasis with sentinels so the spans survive unescaping.
+    let B = "\u{1}", I = "\u{2}", S = "\u{3}"
+    s = sub(s, STRONG, "\(B)$2\(B)")
+    s = sub(s, STRIKE, "\(S)$2\(S)")
+    s = sub(s, EMPH, "\(I)$2\(I)")
+    s = sub(s, ESCAPED, "$1")
+
+    var spans: [Span] = []
+    var cur = ""
+    var bold = false, italic = false, strike = false
+    func flush() {
+        if !cur.isEmpty {
+            spans.append(Span(text: cur, bold: bold || forceBold,
+                              italic: italic, strike: strike))
+            cur = ""
+        }
+    }
+    for ch in s {
+        switch ch {
+        case "\u{1}": flush(); bold.toggle()
+        case "\u{2}": flush(); italic.toggle()
+        case "\u{3}": flush(); strike.toggle()
+        default: cur.append(ch)
+        }
+    }
+    flush()
+    return spans
+}
+
+private func font(_ sp: Span) -> NSFont {
+    var f = sp.bold ? NSFont.boldSystemFont(ofSize: BASE_SIZE)
+                    : NSFont.systemFont(ofSize: BASE_SIZE)
+    if sp.italic {
+        f = NSFontManager.shared.convert(f, toHaveTrait: .italicFontMask)
+    }
+    return f
+}
+
+private func listStyle(_ format: NSTextList.MarkerFormat) -> (NSTextList, NSParagraphStyle) {
+    let list = NSTextList(markerFormat: format, options: 0)
+    let ps = NSMutableParagraphStyle()
+    ps.textLists = [list]
+    ps.headIndent = 24
+    ps.firstLineHeadIndent = 12
+    return (list, ps)
+}
+
+private let quoteStyle: NSParagraphStyle = {
+    let ps = NSMutableParagraphStyle()
+    ps.headIndent = 24
+    ps.firstLineHeadIndent = 24
+    return ps
+}()
+
+/// Render Markdown into an attributed string using Journal's body font.
+func markdownToAttributed(_ md: String) -> NSAttributedString {
+    var kinds: [LineKind] = []
+    var contents: [[Span]] = []
+    var inFence = false
+
+    for raw in md.components(separatedBy: .newlines) {
+        if hits(raw, FENCE) { inFence.toggle(); continue }
+        if inFence {
+            kinds.append(.body)
+            contents.append([Span(text: raw)])
+            continue
+        }
+        if hits(raw, RULE) { continue }            // a rule has no text form
+
+        if let text = capture(raw, HEADING, 2) {
+            kinds.append(.body)
+            contents.append(inlineSpans(text, forceBold: true))
+        } else if let text = capture(raw, BULLET, 1) {
+            kinds.append(.bullet)
+            contents.append(inlineSpans(text, forceBold: false))
+        } else if let text = capture(raw, ORDERED, 1) {
+            kinds.append(.ordered)
+            contents.append(inlineSpans(text, forceBold: false))
+        } else if let text = capture(raw, QUOTE, 1) {
+            kinds.append(.quote)
+            contents.append(inlineSpans(text, forceBold: false))
+        } else {
+            kinds.append(.body)
+            contents.append(inlineSpans(raw, forceBold: false))
+        }
+    }
+
+    let out = NSMutableAttributedString()
+    let plain = NSFont.systemFont(ofSize: BASE_SIZE)
+    var blanks = 0
+    var index = 0
+
+    while index < kinds.count {
+        let kind = kinds[index]
+
+        if kind == .bullet || kind == .ordered {
+            // Consecutive items of one kind form a single list, numbered from 1.
+            let (list, style) = listStyle(kind == .ordered ? .decimal : .disc)
+            var item = 0
+            while index < kinds.count, kinds[index] == kind {
+                item += 1
+                let marker = list.marker(forItemNumber: item)
+                out.append(NSAttributedString(string: "\t\(marker)\t",
+                    attributes: [.font: plain, .paragraphStyle: style]))
+                for sp in contents[index] {
+                    var attrs: [NSAttributedString.Key: Any] =
+                        [.font: font(sp), .paragraphStyle: style]
+                    if sp.strike { attrs[.strikethroughStyle] = 1 }
+                    out.append(NSAttributedString(string: sp.text, attributes: attrs))
+                }
+                out.append(NSAttributedString(string: "\n",
+                    attributes: [.font: plain, .paragraphStyle: style]))
+                index += 1
+            }
+            blanks = 0
+            continue
+        }
+
+        let spans = contents[index]
+        index += 1
+        if spans.allSatisfy({ $0.text.trimmingCharacters(in: .whitespaces).isEmpty }) {
+            // Collapse runs of blanks left behind by dropped rules.
+            blanks += 1
+            if blanks > 1 || out.length == 0 { continue }
+            out.append(NSAttributedString(string: "\n", attributes: [.font: plain]))
+            continue
+        }
+        blanks = 0
+        let style: NSParagraphStyle? = kind == .quote ? quoteStyle : nil
+        for sp in spans {
+            var attrs: [NSAttributedString.Key: Any] = [.font: font(sp)]
+            if sp.strike { attrs[.strikethroughStyle] = 1 }
+            if let style = style { attrs[.paragraphStyle] = style }
+            out.append(NSAttributedString(string: sp.text, attributes: attrs))
+        }
+        out.append(NSAttributedString(string: "\n", attributes: [.font: plain]))
+    }
+
+    while out.length > 0, out.string.hasSuffix("\n") {
+        out.deleteCharacters(in: NSRange(location: out.length - 1, length: 1))
+    }
+    return out
+}
+
+/// Markdown -> (RTF for ZTEXT, plain text for length and emptiness checks).
+func markdownToRTF(_ md: String) -> (data: Data, plain: String) {
+    let att = markdownToAttributed(md)
+    guard let d = att.rtf(from: NSRange(location: 0, length: att.length),
+                          documentAttributes: [:]) else {
+        die("could not build RTF from markdown")
+    }
+    return (d, att.string)
+}
+
+/// Strip Markdown to plain text — for fields like the title that carry no
+/// formatting but still arrive with Markdown escaping in them.
+func markdownToPlain(_ md: String) -> String {
+    markdownToAttributed(md).string
+}

--- a/swift/Sources/journal-cli/Markdown.swift
+++ b/swift/Sources/journal-cli/Markdown.swift
@@ -76,6 +76,9 @@ private func protectInline(_ s: String, _ base: UInt32) -> String {
            let scalar = Unicode.Scalar(base + UInt32(i)) {
             out.unicodeScalars.append(scalar)
         } else {
+            // Markdown only escapes its own punctuation; a backslash before
+            // anything else is literal text, as in a Windows path.
+            out.append("\\")
             out.append(ch)
         }
     }
@@ -103,8 +106,7 @@ private func protectInline(_ s: String, _ base: UInt32) -> String {
         }
     }
     if inCode {                            // unterminated span stays literal
-        out.append(hideAll("`", base))
-        out.append(code)
+        out.append(hideAll("`" + code, base))
     }
     if escaping { out.append("\\") }        // a trailing lone backslash
     return out

--- a/swift/Sources/journal-cli/Markdown.swift
+++ b/swift/Sources/journal-cli/Markdown.swift
@@ -325,8 +325,29 @@ func markdownToRTF(_ md: String) -> (data: Data, plain: String) {
     return (d, att.string)
 }
 
-/// Strip Markdown to plain text — for fields like the title that carry no
-/// formatting but still arrive with Markdown escaping in them.
+/// The text as it reads once stored: rendering to RTF and parsing back drops
+/// generated list marker runs, so this is what a reader of the saved entry
+/// actually sees. Comparing anything else against a stored entry compares
+/// two different things.
 func markdownToPlain(_ md: String) -> String {
-    markdownToAttributed(md).string
+    let att = markdownToAttributed(md)
+    guard let d = att.rtf(from: NSRange(location: 0, length: att.length),
+                          documentAttributes: [:]),
+          let round = NSAttributedString(rtf: d, documentAttributes: nil) else {
+        return att.string
+    }
+    return round.string
+}
+
+/// Inline-only stripping, for single-line fields such as the title. Block
+/// syntax must not apply there: a title of "1. first" is a title, not a list
+/// item, and "---" is a title, not a horizontal rule.
+func markdownToInlinePlain(_ md: String) -> String {
+    let lines = md.replacingOccurrences(of: "\r\n", with: "\n")
+                  .replacingOccurrences(of: "\r", with: "\n")
+                  .components(separatedBy: "\n")
+    return lines
+        .map { inlineSpans($0, forceBold: false).map { $0.text }.joined() }
+        .joined(separator: " ")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
 }

--- a/swift/Sources/journal-cli/Markdown.swift
+++ b/swift/Sources/journal-cli/Markdown.swift
@@ -69,6 +69,47 @@ private func protectEscapes(_ s: String) -> String {
     return out
 }
 
+/// Inline code spans are not styled (Journal has no code run), but their
+/// contents must survive verbatim: "Use `**literal**`" should keep its
+/// asterisks rather than turning "literal" bold. Mapping the span's
+/// delimiters onto the same private-use range hides them from the emphasis
+/// regexes, and restoreEscapes puts them back untouched.
+private func protectCodeSpans(_ s: String) -> String {
+    guard s.contains("`") else { return s }
+    var out = ""
+    var span: String? = nil
+    for ch in s {
+        if ch == "`" {
+            if let body = span {
+                out.append(hideAll("`" + body + "`"))
+                span = nil
+            } else {
+                span = ""
+            }
+        } else if span != nil {
+            span?.append(ch)
+        } else {
+            out.append(ch)
+        }
+    }
+    if let unterminated = span { out.append("`"); out.append(unterminated) }
+    return out
+}
+
+/// Map every escapable character in a string onto the private-use range.
+private func hideAll(_ s: String) -> String {
+    var out = ""
+    for ch in s {
+        if let i = ESCAPABLE.firstIndex(of: ch),
+           let scalar = Unicode.Scalar(ESCAPE_BASE + UInt32(i)) {
+            out.unicodeScalars.append(scalar)
+        } else {
+            out.append(ch)
+        }
+    }
+    return out
+}
+
 private func restoreEscapes(_ s: String) -> String {
     var out = ""
     for ch in s {
@@ -114,7 +155,7 @@ private enum LineKind: Equatable {
 
 /// Pull inline emphasis out of a line, leaving styled spans behind.
 private func inlineSpans(_ line: String, forceBold: Bool) -> [Span] {
-    var s = protectEscapes(line)
+    var s = protectCodeSpans(protectEscapes(line))
 
     // "[text](url)" -> "text (url)", or just the url when the label adds nothing.
     while let m = LINK.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)) {

--- a/swift/Sources/journal-cli/Markdown.swift
+++ b/swift/Sources/journal-cli/Markdown.swift
@@ -337,11 +337,12 @@ func markdownToRTF(_ md: String) -> (data: Data, plain: String) {
                           documentAttributes: [:]) else {
         die("could not build RTF from markdown")
     }
-    // Round-trip for the plain half: callers use it for ZTEXTLENGTH and for
-    // emptiness, and the attributed string still carries generated list
-    // markers that the stored entry will not show.
-    let plain = NSAttributedString(rtf: d, documentAttributes: nil)?.string ?? att.string
-    return (d, plain)
+    // Decode the plain half with rtfToText -- the same function every read
+    // path uses -- so ZTEXTLENGTH and the emptiness check describe exactly
+    // what `show` will return. Doing it any other way drifts: generated list
+    // markers survive the round trip on some macOS releases but not others,
+    // and rtfToText trims surrounding whitespace.
+    return (d, rtfToText(d))
 }
 
 /// The text as it reads once stored: rendering to RTF and parsing back drops
@@ -351,11 +352,10 @@ func markdownToRTF(_ md: String) -> (data: Data, plain: String) {
 func markdownToPlain(_ md: String) -> String {
     let att = markdownToAttributed(md)
     guard let d = att.rtf(from: NSRange(location: 0, length: att.length),
-                          documentAttributes: [:]),
-          let round = NSAttributedString(rtf: d, documentAttributes: nil) else {
-        return att.string
+                          documentAttributes: [:]) else {
+        return att.string.trimmingCharacters(in: .whitespacesAndNewlines)
     }
-    return round.string
+    return rtfToText(d)
 }
 
 /// Inline-only stripping, for single-line fields such as the title. Block

--- a/swift/Sources/journal-cli/Markdown.swift
+++ b/swift/Sources/journal-cli/Markdown.swift
@@ -32,7 +32,9 @@ private let FENCE = rx("^[ \\t]*```")
 private let BULLET = rx("^[ \\t]{0,3}[-*+][ \\t]+(.*)$")
 private let ORDERED = rx("^[ \\t]{0,3}[0-9]{1,9}[.)][ \\t]+(.*)$")
 private let QUOTE = rx("^[ \\t]{0,3}>[ \\t]?(.*)$")
-private let LINK = rx("\\[([^\\]]*)\\]\\(([^)\\s]+)(?:\\s+\"[^\"]*\")?\\)")
+// The negative lookbehind keeps image syntax out: "![alt](url)" is outside
+// this subset, so it survives as written rather than becoming "!alt (url)".
+private let LINK = rx("(?<!!)\\[([^\\]]*)\\]\\(([^)\\s]+)(?:\\s+\"[^\"]*\")?\\)")
 private let TRIPLE_STAR = rx("\\*\\*\\*(?=\\S)(.+?)(?<=\\S)\\*\\*\\*")
 private let TRIPLE_UNDER = rx("(?<![\\w_])___(?=\\S)(.+?)(?<=\\S)___(?![\\w_])")
 private let STRONG_STAR = rx("\\*\\*(?=\\S)(.+?)(?<=\\S)\\*\\*")

--- a/swift/Sources/journal-cli/Markdown.swift
+++ b/swift/Sources/journal-cli/Markdown.swift
@@ -33,6 +33,8 @@ private let BULLET = rx("^[ \\t]{0,3}[-*+][ \\t]+(.*)$")
 private let ORDERED = rx("^[ \\t]{0,3}[0-9]{1,9}[.)][ \\t]+(.*)$")
 private let QUOTE = rx("^[ \\t]{0,3}>[ \\t]?(.*)$")
 private let LINK = rx("\\[([^\\]]*)\\]\\(([^)\\s]+)(?:\\s+\"[^\"]*\")?\\)")
+private let TRIPLE_STAR = rx("\\*\\*\\*(?=\\S)(.+?)(?<=\\S)\\*\\*\\*")
+private let TRIPLE_UNDER = rx("(?<![\\w_])___(?=\\S)(.+?)(?<=\\S)___(?![\\w_])")
 private let STRONG_STAR = rx("\\*\\*(?=\\S)(.+?)(?<=\\S)\\*\\*")
 // Underscores need flanking rules that asterisks do not: "foo__bar__baz" is
 // an identifier, not emphasis.
@@ -60,53 +62,51 @@ private func escapeBase(for s: String) -> UInt32 {
     return 0xE000
 }
 
-private func protectEscapes(_ s: String, _ base: UInt32) -> String {
+// One pass over the line, so precedence is explicit: a backslash escape makes
+// the next character inert, a backtick opens a code span whose contents are
+// taken verbatim (escapes included), and both are hidden in the private-use
+// range where the emphasis regexes cannot see them.
+private func protectInline(_ s: String, _ base: UInt32) -> String {
     var out = ""
     var escaping = false
+    var inCode = false
+    var code = ""
+    func hide(_ ch: Character) {
+        if let i = ESCAPABLE.firstIndex(of: ch),
+           let scalar = Unicode.Scalar(base + UInt32(i)) {
+            out.unicodeScalars.append(scalar)
+        } else {
+            out.append(ch)
+        }
+    }
     for ch in s {
-        if escaping {
-            if let i = ESCAPABLE.firstIndex(of: ch),
-               let scalar = Unicode.Scalar(base + UInt32(i)) {
-                out.unicodeScalars.append(scalar)
+        if inCode {
+            if ch == "`" {
+                out.append(hideAll("`" + code + "`", base))
+                inCode = false
+                code = ""
             } else {
-                out.append("\\")
-                out.append(ch)
+                code.append(ch)
             }
+            continue
+        }
+        if escaping {
+            hide(ch)
             escaping = false
         } else if ch == "\\" {
             escaping = true
+        } else if ch == "`" {
+            inCode = true
+            code = ""
         } else {
             out.append(ch)
         }
+    }
+    if inCode {                            // unterminated span stays literal
+        out.append(hideAll("`", base))
+        out.append(code)
     }
     if escaping { out.append("\\") }        // a trailing lone backslash
-    return out
-}
-
-/// Inline code spans are not styled (Journal has no code run), but their
-/// contents must survive verbatim: "Use `**literal**`" should keep its
-/// asterisks rather than turning "literal" bold. Mapping the span's
-/// delimiters onto the same private-use range hides them from the emphasis
-/// regexes, and restoreEscapes puts them back untouched.
-private func protectCodeSpans(_ s: String, _ base: UInt32) -> String {
-    guard s.contains("`") else { return s }
-    var out = ""
-    var span: String? = nil
-    for ch in s {
-        if ch == "`" {
-            if let body = span {
-                out.append(hideAll("`" + body + "`", base))
-                span = nil
-            } else {
-                span = ""
-            }
-        } else if span != nil {
-            span?.append(ch)
-        } else {
-            out.append(ch)
-        }
-    }
-    if let unterminated = span { out.append("`"); out.append(unterminated) }
     return out
 }
 
@@ -170,7 +170,7 @@ private enum LineKind: Equatable {
 /// Pull inline emphasis out of a line, leaving styled spans behind.
 private func inlineSpans(_ line: String, forceBold: Bool) -> [Span] {
     let base = escapeBase(for: line)
-    var s = protectCodeSpans(protectEscapes(line, base), base)
+    var s = protectInline(line, base)
 
     // "[text](url)" -> "text (url)", or just the url when the label adds nothing.
     while let m = LINK.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)) {
@@ -184,6 +184,10 @@ private func inlineSpans(_ line: String, forceBold: Bool) -> [Span] {
 
     // Mark emphasis with sentinels so the spans survive unescaping.
     let B = "\u{1}", I = "\u{2}", S = "\u{3}"
+    // Triple delimiters first: otherwise the strong pass eats two and the
+    // emphasis pass eats the rest, losing bold from "***both***".
+    s = sub(s, TRIPLE_STAR, "\(B)\(I)$1\(I)\(B)")
+    s = sub(s, TRIPLE_UNDER, "\(B)\(I)$1\(I)\(B)")
     s = sub(s, STRONG_STAR, "\(B)$1\(B)")
     s = sub(s, STRONG_UNDER, "\(B)$1\(B)")
     s = sub(s, STRIKE, "\(S)$2\(S)")

--- a/swift/Sources/journal-cli/Model.swift
+++ b/swift/Sources/journal-cli/Model.swift
@@ -172,6 +172,26 @@ func resolveJournal(_ db: DB, _ sel: String) -> JournalRow {
         + hits.map { String($0.pk) }.joined(separator: ", "))
 }
 
+/// Journal syncs custom-journal membership from the JournalMO record, not from
+/// the entry record. Any join-table change therefore has to dirty the affected
+/// custom journal as well as the entry; otherwise the relationship is local-only
+/// and other devices place the entry in the default journal.
+func markJournalsUnsynced(_ db: DB, _ journalPKs: [Int64]) {
+    let pks = Array(Set(journalPKs))
+    for pk in pks {
+        db.exec("""
+            update ZJOURNALMO
+            set ZISUPLOADEDTOCLOUD=0, Z_OPT=coalesce(Z_OPT,0)+1
+            where Z_PK=? and not (ZMERGEABLEATTRIBUTES is null and ZSORTCATEGORY < 0)
+            """, [pk])
+    }
+}
+
+func journalPKsForEntry(_ db: DB, _ entryPK: Int64) -> [Int64] {
+    db.query("select Z_6JOURNALS from Z_5JOURNALS where Z_5ENTRIES=?", [entryPK])
+        .compactMap { $0.i("Z_6JOURNALS") }
+}
+
 // ---------------------------------------------------------------- write helpers
 
 func nextPK(_ db: DB, _ entityName: String) -> (ent: Int64, pk: Int64) {

--- a/swift/Sources/journal-cli/WriteCommands.swift
+++ b/swift/Sources/journal-cli/WriteCommands.swift
@@ -38,6 +38,18 @@ private func readBody(_ a: Args) -> String? {
     return nil
 }
 
+// Render Markdown the way `write --markdown` would, without touching a store.
+// Lets callers compare an entry's stored text against what it *should* be,
+// which is exact where sniffing for leftover syntax is guesswork.
+func cmdRender(_ a: Args) {
+    let md = readBody(a) ?? ""
+    if a.has("--plain") {
+        FileHandle.standardOutput.write(Data(markdownToPlain(md).utf8))
+    } else {
+        FileHandle.standardOutput.write(markdownToRTF(md).data)
+    }
+}
+
 func cmdWrite(_ a: Args) {
     let rtfBody = readBodyRTF(a)
     let body = rtfBody?.plain ?? (readBody(a) ?? "")

--- a/swift/Sources/journal-cli/WriteCommands.swift
+++ b/swift/Sources/journal-cli/WriteCommands.swift
@@ -43,7 +43,9 @@ private func readBody(_ a: Args) -> String? {
 // which is exact where sniffing for leftover syntax is guesswork.
 func cmdRender(_ a: Args) {
     let md = readBody(a) ?? ""
-    if a.has("--plain") {
+    if a.has("--inline") {
+        FileHandle.standardOutput.write(Data(markdownToInlinePlain(md).utf8))
+    } else if a.has("--plain") {
         FileHandle.standardOutput.write(Data(markdownToPlain(md).utf8))
     } else {
         FileHandle.standardOutput.write(markdownToRTF(md).data)
@@ -75,14 +77,14 @@ func cmdWrite(_ a: Args) {
     if hasLoc && (lat == nil || lon == nil) { die("--lat and --lon must be given together") }
     let link = a.value("--link")
     let hasText = !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    if !hasText && media.isEmpty && lp == nil && !hasLoc && link == nil {
-        die("nothing to write (need --body/--body-file/stdin, --media, --live-photo, --link, or --lat/--lon)")
+    let title = a.value("--title").map { a.has("--markdown") ? markdownToInlinePlain($0) : $0 }
+    if !hasText && title == nil && media.isEmpty && lp == nil && !hasLoc && link == nil {
+        die("nothing to write (need --title, --body/--body-file/stdin, --media, --live-photo, --link, or --lat/--lon)")
     }
 
     let when = a.value("--date").map(parseDate) ?? Date()
     let ts = cd(when)
     let entryUUID = uid()
-    let title = a.value("--title").map { a.has("--markdown") ? markdownToPlain($0) : $0 }
 
     if a.has("--dry-run") {
         var bits: [String] = []
@@ -201,7 +203,7 @@ func cmdEdit(_ a: Args) {
     let rtfBody = readBodyRTF(a)
     guard let idStr = a.positional.first, let pk = Int64(idStr) else { die("edit needs an entry id") }
     let body = rtfBody?.plain ?? readBody(a)
-    let title = a.value("--title").map { a.has("--markdown") ? markdownToPlain($0) : $0 }
+    let title = a.value("--title").map { a.has("--markdown") ? markdownToInlinePlain($0) : $0 }
     let media = a.values("--add-media").map { (($0 as NSString).expandingTildeInPath as NSString).standardizingPath }
     for m in media where !FileManager.default.fileExists(atPath: m) {
         die("media file not found: \(m)")

--- a/swift/Sources/journal-cli/WriteCommands.swift
+++ b/swift/Sources/journal-cli/WriteCommands.swift
@@ -91,6 +91,7 @@ func cmdWrite(_ a: Args) {
 
     if a.has("--dry-run") {
         var bits: [String] = []
+        if hasTitle { bits.append("title") }
         if hasText { bits.append("\(body.count) chars") }
         if !media.isEmpty { bits.append("\(media.count) media") }
         if lp != nil { bits.append("1 live photo") }
@@ -188,6 +189,7 @@ func cmdWrite(_ a: Args) {
     }
 
     var bits: [String] = []
+    if hasTitle { bits.append("title") }
     if hasText { bits.append("\(body.count) chars") }
     if !media.isEmpty { bits.append("\(media.count) media") }
     if lp != nil { bits.append("1 live photo") }

--- a/swift/Sources/journal-cli/WriteCommands.swift
+++ b/swift/Sources/journal-cli/WriteCommands.swift
@@ -78,7 +78,8 @@ func cmdWrite(_ a: Args) {
     let link = a.value("--link")
     let hasText = !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     let title = a.value("--title").map { a.has("--markdown") ? markdownToInlinePlain($0) : $0 }
-    if !hasText && title == nil && media.isEmpty && lp == nil && !hasLoc && link == nil {
+    let hasTitle = !(title ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    if !hasText && !hasTitle && media.isEmpty && lp == nil && !hasLoc && link == nil {
         die("nothing to write (need --title, --body/--body-file/stdin, --media, --live-photo, --link, or --lat/--lon)")
     }
 

--- a/swift/Sources/journal-cli/WriteCommands.swift
+++ b/swift/Sources/journal-cli/WriteCommands.swift
@@ -176,6 +176,7 @@ func cmdWrite(_ a: Args) {
             if !j.isDefault {
                 db.exec("insert or ignore into Z_5JOURNALS (Z_5ENTRIES, Z_6JOURNALS) values (?,?)",
                         [pk, j.pk])
+                markJournalsUnsynced(db, [j.pk])
             }
         }
         return pk
@@ -330,10 +331,12 @@ func cmdEdit(_ a: Args) {
 
         if let jsel = a.value("--journal") {
             let j = resolveJournal(db, jsel)
+            let oldJournalPKs = journalPKsForEntry(db, pk)
             db.exec("delete from Z_5JOURNALS where Z_5ENTRIES=?", [pk])
             if !j.isDefault {
                 db.exec("insert into Z_5JOURNALS (Z_5ENTRIES, Z_6JOURNALS) values (?,?)", [pk, j.pk])
             }
+            markJournalsUnsynced(db, oldJournalPKs + (j.isDefault ? [] : [j.pk]))
         }
     }
 
@@ -371,6 +374,7 @@ func cmdDelete(_ a: Args) {
                 + "  Journal.app, or pass --force if you accept the resurrection risk.")
         }
         if a.has("--hard") {
+            let oldJournalPKs = journalPKsForEntry(db, pk)
             let apks = db.query("select Z_PK from ZJOURNALENTRYASSETMO where ZENTRY=?", [pk])
                 .compactMap { $0.i("Z_PK") }
             for apk in apks {
@@ -379,6 +383,7 @@ func cmdDelete(_ a: Args) {
             db.exec("delete from ZJOURNALENTRYASSETMO where ZENTRY=?", [pk])
             db.exec("delete from Z_5JOURNALS where Z_5ENTRIES=?", [pk])
             db.exec("delete from ZJOURNALENTRYMO where Z_PK=?", [pk])
+            markJournalsUnsynced(db, oldJournalPKs)
             if let eu = uString(row.b("ZID")) {
                 try? FileManager.default.removeItem(atPath: attachDir() + "/" + eu)
             }
@@ -435,6 +440,7 @@ func cmdEmpty(_ a: Args) {
             """) {
             if r.flag("ZISUPLOADEDTOCLOUD") && !a.has("--force") { skipped += 1; continue }
             let pk = r.i("Z_PK") ?? 0
+            let oldJournalPKs = journalPKsForEntry(db, pk)
             for apk in db.query("select Z_PK from ZJOURNALENTRYASSETMO where ZENTRY=?", [pk])
                 .compactMap({ $0.i("Z_PK") }) {
                 db.exec("delete from ZJOURNALENTRYASSETFILEATTACHMENTMO where ZASSET=?", [apk])
@@ -442,6 +448,7 @@ func cmdEmpty(_ a: Args) {
             db.exec("delete from ZJOURNALENTRYASSETMO where ZENTRY=?", [pk])
             db.exec("delete from Z_5JOURNALS where Z_5ENTRIES=?", [pk])
             db.exec("delete from ZJOURNALENTRYMO where Z_PK=?", [pk])
+            markJournalsUnsynced(db, oldJournalPKs)
             if let eu = uString(r.b("ZID")) {
                 try? FileManager.default.removeItem(atPath: attachDir() + "/" + eu)
             }
@@ -455,6 +462,36 @@ func cmdEmpty(_ a: Args) {
             + " Empty Recently Deleted in Journal.app instead (or --force to purge anyway)."
     }
     print(msg)
+}
+
+func cmdSyncJournals(_ a: Args) {
+    let selected = a.value("--journal")
+    if a.has("--dry-run") {
+        let rows: [JournalRow] = withSnapshot { db in
+            if let selected {
+                let journal = resolveJournal(db, selected)
+                if journal.isDefault { die("the default journal has no custom membership record to sync") }
+                return [journal]
+            }
+            return journalRows(db).filter { !$0.isDefault }
+        }
+        print("DRY RUN: would queue \(rows.count) custom journal\(rows.count == 1 ? "" : "s") for membership re-upload. Nothing written.")
+        return
+    }
+
+    let count: Int = withLive(allowLiveDefault: a.has("--live"), acceptRisk: a.has("--accept-risk")) { db in
+        let rows: [JournalRow]
+        if let selected {
+            let journal = resolveJournal(db, selected)
+            if journal.isDefault { die("the default journal has no custom membership record to sync") }
+            rows = [journal]
+        } else {
+            rows = journalRows(db).filter { !$0.isDefault }
+        }
+        markJournalsUnsynced(db, rows.map(\.pk))
+        return rows.count
+    }
+    print("Queued \(count) custom journal\(count == 1 ? "" : "s") for membership re-upload. Open Journal.app to sync the corrected memberships to other devices.")
 }
 
 func cmdSandbox(_ a: Args) {

--- a/swift/Sources/journal-cli/WriteCommands.swift
+++ b/swift/Sources/journal-cli/WriteCommands.swift
@@ -13,10 +13,12 @@ private func readBodyRTF(_ a: Args) -> (data: Data, plain: String)? {
     guard let d = FileManager.default.contents(atPath: full) else {
         die("cannot read --body-rtf file: \(path)")
     }
-    guard let att = NSAttributedString(rtf: d, documentAttributes: nil) else {
+    guard NSAttributedString(rtf: d, documentAttributes: nil) != nil else {
         die("--body-rtf is not valid RTF: \(path)")
     }
-    return (d, att.string)
+    // rtfToText is what every read path uses, so ZTEXTLENGTH and the
+    // emptiness check describe what `show` will actually return.
+    return (d, rtfToText(d))
 }
 
 private func readBody(_ a: Args) -> String? {

--- a/swift/Sources/journal-cli/WriteCommands.swift
+++ b/swift/Sources/journal-cli/WriteCommands.swift
@@ -1,6 +1,24 @@
 // WriteCommands.swift — write, edit, delete, restore, empty, sandbox.
 import Foundation
 
+// Journal stores entry text as RTF and renders its formatting, so callers
+// that already have styled text can hand it over verbatim instead of having
+// it flattened through textToRTF.
+private func readBodyRTF(_ a: Args) -> (data: Data, plain: String)? {
+    // Markdown is rendered into Journal's own rich text; Journal shows no
+    // Markdown syntax, so leaving it in place would print it literally.
+    if a.has("--markdown"), let md = readBody(a) { return markdownToRTF(md) }
+    guard let path = a.value("--body-rtf") else { return nil }
+    let full = (path as NSString).expandingTildeInPath
+    guard let d = FileManager.default.contents(atPath: full) else {
+        die("cannot read --body-rtf file: \(path)")
+    }
+    guard let att = NSAttributedString(rtf: d, documentAttributes: nil) else {
+        die("--body-rtf is not valid RTF: \(path)")
+    }
+    return (d, att.string)
+}
+
 private func readBody(_ a: Args) -> String? {
     if let b = a.value("--body") { return b }
     if let f = a.value("--body-file") {
@@ -21,7 +39,8 @@ private func readBody(_ a: Args) -> String? {
 }
 
 func cmdWrite(_ a: Args) {
-    let body = readBody(a) ?? ""
+    let rtfBody = readBodyRTF(a)
+    let body = rtfBody?.plain ?? (readBody(a) ?? "")
     let media = a.values("--media").map { (($0 as NSString).expandingTildeInPath as NSString).standardizingPath }
     for m in media where !FileManager.default.fileExists(atPath: m) {
         die("media file not found: \(m)")
@@ -51,7 +70,7 @@ func cmdWrite(_ a: Args) {
     let when = a.value("--date").map(parseDate) ?? Date()
     let ts = cd(when)
     let entryUUID = uid()
-    let title = a.value("--title")
+    let title = a.value("--title").map { a.has("--markdown") ? markdownToPlain($0) : $0 }
 
     if a.has("--dry-run") {
         var bits: [String] = []
@@ -77,7 +96,7 @@ func cmdWrite(_ a: Args) {
                ZMINIMUMSUPPORTEDAPPVERSION, ZMINIMUMSUPPORTEDAPPVERSIONMODE)
             values (?,?,1,'blankEntry',?, ?,?,?,?, ?,?,?,?, 0,?,0,0, 0,0,0, 0,0)
             """, [pk, ent, uidBytes(entryUUID), ts, cdNow(), cdNow(), ts,
-                  hasText ? textToRTF(body) : nil,
+                  hasText ? (rtfBody?.data ?? textToRTF(body)) : nil,
                   title.map(textToRTF),
                   body.count, title != nil ? 1 : 0,
                   a.has("--bookmark") ? 1 : 0])
@@ -166,9 +185,10 @@ func cmdWrite(_ a: Args) {
 }
 
 func cmdEdit(_ a: Args) {
+    let rtfBody = readBodyRTF(a)
     guard let idStr = a.positional.first, let pk = Int64(idStr) else { die("edit needs an entry id") }
-    let body = readBody(a)
-    let title = a.value("--title")
+    let body = rtfBody?.plain ?? readBody(a)
+    let title = a.value("--title").map { a.has("--markdown") ? markdownToPlain($0) : $0 }
     let media = a.values("--add-media").map { (($0 as NSString).expandingTildeInPath as NSString).standardizingPath }
     for m in media where !FileManager.default.fileExists(atPath: m) {
         die("media file not found: \(m)")
@@ -211,9 +231,9 @@ func cmdEdit(_ a: Args) {
         var sets: [String] = []
         var vals: [Any?] = []
         if let b = body {
+            let blank = b.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             sets += ["ZTEXT=?", "ZTEXTLENGTH=?"]
-            vals += [b.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : textToRTF(b),
-                     b.count]
+            vals += [blank ? nil : (rtfBody?.data ?? textToRTF(b)), b.count]
         }
         if let t = title {
             let empty = t.trimmingCharacters(in: .whitespaces).isEmpty

--- a/swift/Sources/journal-cli/main.swift
+++ b/swift/Sources/journal-cli/main.swift
@@ -35,6 +35,8 @@ WRITE (guarded: --live required against the real store; auto-backup first)
   restore   <id> [--live]
   empty     [--force] [--live]
   sandbox   --dir DIR [--from DB]      copy the store somewhere safe for testing
+  render    [--body B | --body-file F | stdin] [--plain]
+            render Markdown to RTF (or plain text) on stdout; writes nothing
 
   --markdown renders the body (and de-escapes the title) as Markdown into
   Journal's rich text: headings and **bold** become real formatting rather
@@ -60,7 +62,7 @@ guard let cmd = argv.first, cmd != "--help", cmd != "-h", cmd != "help" else {
 let rest = Array(argv.dropFirst())
 
 let boolFlags: Set<String> = ["--json", "--full", "--include-empty", "--bookmark",
-                              "--dry-run", "--accept-risk", "--markdown",
+                              "--dry-run", "--accept-risk", "--markdown", "--plain",
                               "--no-bookmark", "--live", "--hard", "--force",
                               "--clear-location", "--remove-all-media",
                               "--photos-link", "--no-resize"]
@@ -87,6 +89,7 @@ case "delete":   cmdDelete(a)
 case "restore":  cmdRestore(a)
 case "empty":    cmdEmpty(a)
 case "sandbox":  cmdSandbox(a)
+case "render":   cmdRender(a)
 default:
     die("unknown command '\(cmd)'\n\n\(HELP)")
 }

--- a/swift/Sources/journal-cli/main.swift
+++ b/swift/Sources/journal-cli/main.swift
@@ -34,6 +34,8 @@ WRITE (guarded: --live required against the real store; auto-backup first)
   delete    <id> [--hard] [--force] [--live]
   restore   <id> [--live]
   empty     [--force] [--live]
+  sync-journals [--journal NAME] [--live]
+            re-upload custom-journal memberships after a direct-store import
   sandbox   --dir DIR [--from DB]      copy the store somewhere safe for testing
   render    [--body B | --body-file F | stdin] [--plain]
             render Markdown to RTF (or plain text) on stdout; writes nothing
@@ -88,6 +90,7 @@ case "edit":     cmdEdit(a)
 case "delete":   cmdDelete(a)
 case "restore":  cmdRestore(a)
 case "empty":    cmdEmpty(a)
+case "sync-journals": cmdSyncJournals(a)
 case "sandbox":  cmdSandbox(a)
 case "render":   cmdRender(a)
 default:

--- a/swift/Sources/journal-cli/main.swift
+++ b/swift/Sources/journal-cli/main.swift
@@ -20,11 +20,12 @@ READ
   doctor
 
 WRITE (guarded: --live required against the real store; auto-backup first)
-  write     [--title T] [--body B] [--body-file F] [--date D] [--bookmark]
+  write     [--title T] [--body B] [--body-file F] [--body-rtf F] [--date D] [--bookmark]
+            [--markdown]
             [--media PATH...] [--live-photo IMAGE VIDEO] [--no-resize]
             [--photos-link] [--link URL] [--link-title T]
             [--lat N --lon N] [--place P] [--city C] [--journal NAME] [--live]
-  edit      <id> [--title T] [--body B] [--body-file F] [--date D]
+  edit      <id> [--title T] [--body B] [--body-file F] [--body-rtf F] [--date D]
             [--bookmark | --no-bookmark] [--add-media PATH...] [--no-resize]
             [--photos-link] [--add-link URL] [--link-title T]
             [--lat N --lon N] [--place P] [--city C] [--clear-location]
@@ -34,6 +35,10 @@ WRITE (guarded: --live required against the real store; auto-backup first)
   restore   <id> [--live]
   empty     [--force] [--live]
   sandbox   --dir DIR [--from DB]      copy the store somewhere safe for testing
+
+  --markdown renders the body (and de-escapes the title) as Markdown into
+  Journal's rich text: headings and **bold** become real formatting rather
+  than literal syntax. --body-rtf F stores a prepared RTF file verbatim.
 
   Every mutating command also takes --dry-run (print the plan, write nothing)
   and --accept-risk (one-time risk acknowledgment; see the README warning).
@@ -55,12 +60,12 @@ guard let cmd = argv.first, cmd != "--help", cmd != "-h", cmd != "help" else {
 let rest = Array(argv.dropFirst())
 
 let boolFlags: Set<String> = ["--json", "--full", "--include-empty", "--bookmark",
-                              "--dry-run", "--accept-risk",
+                              "--dry-run", "--accept-risk", "--markdown",
                               "--no-bookmark", "--live", "--hard", "--force",
                               "--clear-location", "--remove-all-media",
                               "--photos-link", "--no-resize"]
 let valueFlags: Set<String> = ["--limit", "--since", "--until", "--dir", "--format",
-                               "--title", "--body", "--body-file", "--date",
+                               "--title", "--body", "--body-file", "--body-rtf", "--date",
                                "--lat", "--lon", "--place", "--city", "--journal",
                                "--link", "--link-title", "--add-link", "--from"]
 let listFlags: Set<String> = ["--media", "--add-media", "--live-photo", "--remove-media"]

--- a/swift/Sources/journal-cli/main.swift
+++ b/swift/Sources/journal-cli/main.swift
@@ -37,7 +37,7 @@ WRITE (guarded: --live required against the real store; auto-backup first)
   sync-journals [--journal NAME] [--live]
             re-upload custom-journal memberships after a direct-store import
   sandbox   --dir DIR [--from DB]      copy the store somewhere safe for testing
-  render    [--body B | --body-file F | stdin] [--plain]
+  render    [--body B | --body-file F | stdin] [--plain | --inline]
             render Markdown to RTF (or plain text) on stdout; writes nothing
 
   --markdown renders the body (and de-escapes the title) as Markdown into
@@ -64,7 +64,7 @@ guard let cmd = argv.first, cmd != "--help", cmd != "-h", cmd != "help" else {
 let rest = Array(argv.dropFirst())
 
 let boolFlags: Set<String> = ["--json", "--full", "--include-empty", "--bookmark",
-                              "--dry-run", "--accept-risk", "--markdown", "--plain",
+                              "--dry-run", "--accept-risk", "--markdown", "--plain", "--inline",
                               "--no-bookmark", "--live", "--hard", "--force",
                               "--clear-location", "--remove-all-media",
                               "--photos-link", "--no-resize"]

--- a/tests/make-fixture.sh
+++ b/tests/make-fixture.sh
@@ -8,11 +8,19 @@ DIR="${1:?usage: make-fixture.sh DIR}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 mkdir -p "$DIR"
 DB="$DIR/moments.sqlite"
-# `trash` is macOS 26+; CI runs older releases, so fall back there.
-for f in "$DB" "$DB-wal" "$DB-shm"; do
-  [ -e "$f" ] || continue
-  if command -v trash >/dev/null 2>&1; then trash "$f"; else rm -f "$f"; fi
-done
+# Retire any previous fixture instead of deleting it: `trash` is macOS 26+,
+# and on older hosts moving it aside keeps the old copy recoverable.
+if [ -e "$DB" ]; then
+  if command -v trash >/dev/null 2>&1; then
+    for f in "$DB" "$DB-wal" "$DB-shm"; do [ -e "$f" ] && trash "$f"; done
+  else
+    OLD="$DIR/superseded-$$"
+    mkdir -p "$OLD"
+    for f in "$DB" "$DB-wal" "$DB-shm"; do
+      [ -e "$f" ] && mv "$f" "$OLD/"
+    done
+  fi
+fi
 
 sqlite3 "$DB" < "$HERE/fixture-schema.sql"
 

--- a/tests/make-fixture.sh
+++ b/tests/make-fixture.sh
@@ -8,7 +8,11 @@ DIR="${1:?usage: make-fixture.sh DIR}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 mkdir -p "$DIR"
 DB="$DIR/moments.sqlite"
-if [ -e "$DB" ]; then /usr/bin/trash "$DB"; fi
+# `trash` is macOS 26+; CI runs older releases, so fall back there.
+for f in "$DB" "$DB-wal" "$DB-shm"; do
+  [ -e "$f" ] || continue
+  if command -v trash >/dev/null 2>&1; then trash "$f"; else rm -f "$f"; fi
+done
 
 sqlite3 "$DB" < "$HERE/fixture-schema.sql"
 

--- a/tests/make-fixture.sh
+++ b/tests/make-fixture.sh
@@ -8,7 +8,7 @@ DIR="${1:?usage: make-fixture.sh DIR}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 mkdir -p "$DIR"
 DB="$DIR/moments.sqlite"
-rm -f "$DB" 2>/dev/null || :
+if [ -e "$DB" ]; then /usr/bin/trash "$DB"; fi
 
 sqlite3 "$DB" < "$HERE/fixture-schema.sql"
 

--- a/tests/test_write.sh
+++ b/tests/test_write.sh
@@ -390,6 +390,9 @@ if [ $? -eq 0 ]; then
   ok "render --plain works"           "$(printf '###### H' | "$CLI" render --plain)" "H"
   ok "inline code kept verbatim"      "$(printf 'Use `**lit**` here' | "$CLI" render --plain)" "Use \`**lit**\` here"
   ok "title keeps list-like text"     "$(printf '1. first' | "$CLI" render --inline)" "1. first"
+  ok "backslash before non-escapable" "$(printf 'C:\\Users\\omar' | "$CLI" render --plain)" 'C:\Users\omar'
+  ok "unterminated code stays literal" "$(printf 'a `**x** b' | "$CLI" render --plain)" 'a `**x** b'
+  ok "unterminated code not bolded"   "$(printf 'a `**x** b' | "$CLI" render | grep -c 'Bold')" "0"
   TRI=$(printf '***both***' | "$CLI" render)
   ok "triple emphasis is bold"        "$(printf '%s' "$TRI" | grep -c 'Bold')" "1"
   ok "triple emphasis is italic"      "$(printf '%s' "$TRI" | grep -c 'Italic')" "1"

--- a/tests/test_write.sh
+++ b/tests/test_write.sh
@@ -390,6 +390,11 @@ if [ $? -eq 0 ]; then
   ok "render --plain works"           "$(printf '###### H' | "$CLI" render --plain)" "H"
   ok "inline code kept verbatim"      "$(printf 'Use `**lit**` here' | "$CLI" render --plain)" "Use \`**lit**\` here"
   ok "title keeps list-like text"     "$(printf '1. first' | "$CLI" render --inline)" "1. first"
+  TRI=$(printf '***both***' | "$CLI" render)
+  ok "triple emphasis is bold"        "$(printf '%s' "$TRI" | grep -c 'Bold')" "1"
+  ok "triple emphasis is italic"      "$(printf '%s' "$TRI" | grep -c 'Italic')" "1"
+  ok "escapes verbatim in code"       "$(printf 'a `\\*x\\*` b' | "$CLI" render --plain)" "a \`\\*x\\*\` b"
+  ok "escapes applied outside code"   "$(printf 'a \\*x\\* b' | "$CLI" render --plain)" "a *x* b"
   PUA=$(python3 -c 'import sys;sys.stdout.write("a\ue000b")')
   ok "private-use scalar survives"    "$(printf '%s' "$PUA" | "$CLI" render --plain)" "$PUA"
   "$CLI" --db "$DB" write --markdown --title '   ' >/dev/null 2>&1

--- a/tests/test_write.sh
+++ b/tests/test_write.sh
@@ -318,6 +318,42 @@ ok "delete dry-run left row" "$(sqlite3 "$DB" "select coalesce(ZRECENTLYDELETED,
 ok "edit dry-run validates id" "$?" "1"
 "$CLI" --db "$DB" delete $DRPK --hard >/dev/null 2>&1
 
+echo "T17 markdown rendering"
+MD=$(printf '###### Reflect on today:\n1\\. first thing\n\n---\n\nIt was **hard**\\. See [my site](https://example.com)\n\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e \xf0\x9f\x9a\x95')
+MDOUT=$(printf '%s' "$MD" | "$CLI" --db "$DB" write --title 'Day 9 \- Naoshima' --markdown 2>&1)
+MDPK=$(echo "$MDOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+MDTEXT=$("$CLI" --db "$DB" show $MDPK --json | jq_ 'd["text"]')
+ok "heading marker stripped"  "$(printf '%s' "$MDTEXT" | grep -c '#')" "0"
+ok "escapes removed"          "$(printf '%s' "$MDTEXT" | grep -c '\\\\\.')" "0"
+ok "horizontal rule dropped"  "$(printf '%s' "$MDTEXT" | grep -cE '^---$')" "0"
+ok "emphasis markers gone"    "$(printf '%s' "$MDTEXT" | grep -c '\*\*')" "0"
+ok "heading text kept"        "$(printf '%s' "$MDTEXT" | grep -c 'Reflect on today:')" "1"
+ok "link flattened"           "$(printf '%s' "$MDTEXT" | grep -c 'my site (https://example.com)')" "1"
+JP=$(printf '\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e')
+ok "unicode preserved"        "$(printf '%s' "$MDTEXT" | grep -cF "$JP")" "1"
+ok "title de-escaped"         "$("$CLI" --db "$DB" show $MDPK --json | jq_ 'd["title"]')" "Day 9 - Naoshima"
+ok "bold run in RTF"          "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'\\b') > 0 from ZJOURNALENTRYMO where Z_PK=$MDPK;")" "1"
+ok "bold font in RTF"         "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'Bold') > 0 from ZJOURNALENTRYMO where Z_PK=$MDPK;")" "1"
+LMD=$(printf -- '- alpha\n- beta\n\n1. one\n2. two\n\n~~gone~~ and *slanted*')
+LOUT=$(printf '%s' "$LMD" | "$CLI" --db "$DB" write --markdown 2>&1)
+LPK3=$(echo "$LOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+LRTF=$(sqlite3 "$DB" "select cast(ZTEXT as text) from ZJOURNALENTRYMO where Z_PK=$LPK3;")
+ok "bulleted list in RTF"  "$(printf '%s' "$LRTF" | grep -c 'disc')" "1"
+ok "numbered list in RTF"  "$(printf '%s' "$LRTF" | grep -c 'decimal')" "1"
+ok "list markers emitted"  "$(printf '%s' "$LRTF" | grep -q 'listtext' && echo 1 || echo 0)" "1"
+ok "strikethrough in RTF"  "$(printf '%s' "$LRTF" | grep -c 'strike')" "1"
+ok "italic in RTF"         "$(printf '%s' "$LRTF" | grep -cE '\\i[ 0]')" "1"
+ok "list bullets stripped" "$("$CLI" --db "$DB" show $LPK3 --json | jq_ 'd["text"]' | grep -c '^- ')" "0"
+ESC=$(printf -- '1\\. literal not a list')
+EOUT3=$(printf '%s' "$ESC" | "$CLI" --db "$DB" write --markdown 2>&1)
+EPK3=$(echo "$EOUT3" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+ok "escaped number stays plain" "$("$CLI" --db "$DB" show $EPK3 --json | jq_ 'd["text"]')" "1. literal not a list"
+ok "escaped number is not a list" "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'listtext') from ZJOURNALENTRYMO where Z_PK=$EPK3;")" "0"
+
+PLAINOUT=$("$CLI" --db "$DB" write --body '## not markdown mode' 2>&1)
+PLAINPK=$(echo "$PLAINOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+ok "plain mode leaves text alone" "$("$CLI" --db "$DB" show $PLAINPK --json | jq_ 'd["text"]')" "## not markdown mode"
+
 echo "T8 integrity"
 ok "integrity_check" "$(sqlite3 "$DB" 'PRAGMA integrity_check;' | head -1)" "ok"
 SEEDCOUNT=$(sqlite3 "${JOURNAL_SEED:-$DB}" 'select count(*) from ZJOURNALENTRYMO;' 2>/dev/null)

--- a/tests/test_write.sh
+++ b/tests/test_write.sh
@@ -318,52 +318,65 @@ ok "delete dry-run left row" "$(sqlite3 "$DB" "select coalesce(ZRECENTLYDELETED,
 ok "edit dry-run validates id" "$?" "1"
 "$CLI" --db "$DB" delete $DRPK --hard >/dev/null 2>&1
 
-echo "T17 markdown rendering"
-MD=$(printf '###### Reflect on today:\n1\\. first thing\n\n---\n\nIt was **hard**\\. See [my site](https://example.com)\n\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e \xf0\x9f\x9a\x95')
-MDOUT=$(printf '%s' "$MD" | "$CLI" --db "$DB" write --title 'Day 9 \- Naoshima' --markdown 2>&1)
-MDPK=$(echo "$MDOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
-MDTEXT=$("$CLI" --db "$DB" show $MDPK --json | jq_ 'd["text"]')
-ok "heading marker stripped"  "$(printf '%s' "$MDTEXT" | grep -c '#')" "0"
-ok "escapes removed"          "$(printf '%s' "$MDTEXT" | grep -c '\\\\\.')" "0"
-ok "horizontal rule dropped"  "$(printf '%s' "$MDTEXT" | grep -cE '^---$')" "0"
-ok "emphasis markers gone"    "$(printf '%s' "$MDTEXT" | grep -c '\*\*')" "0"
-ok "heading text kept"        "$(printf '%s' "$MDTEXT" | grep -c 'Reflect on today:')" "1"
-ok "link flattened"           "$(printf '%s' "$MDTEXT" | grep -c 'my site (https://example.com)')" "1"
-JP=$(printf '\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e')
-ok "unicode preserved"        "$(printf '%s' "$MDTEXT" | grep -cF "$JP")" "1"
-ok "title de-escaped"         "$("$CLI" --db "$DB" show $MDPK --json | jq_ 'd["title"]')" "Day 9 - Naoshima"
-ok "bold run in RTF"          "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'\\b')>0 from ZJOURNALENTRYMO where Z_PK=$MDPK;")" "1"
-ok "bold font in RTF"         "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'Bold')>0 from ZJOURNALENTRYMO where Z_PK=$MDPK;")" "1"
-LMD=$(printf -- '- alpha\n- beta\n\n1. one\n2. two\n\n~~gone~~ and *slanted*')
-LOUT=$(printf '%s' "$LMD" | "$CLI" --db "$DB" write --markdown 2>&1)
-LPK3=$(echo "$LOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
-rtfhas() { sqlite3 "$DB" "select instr(cast(ZTEXT as text),'$2')>0 from ZJOURNALENTRYMO where Z_PK=$1;"; }
-ok "bulleted list in RTF"  "$(rtfhas $LPK3 disc)" "1"
-ok "numbered list in RTF"  "$(rtfhas $LPK3 decimal)" "1"
-ok "list markers emitted"  "$(rtfhas $LPK3 listtext)" "1"
-ok "strikethrough in RTF"  "$(rtfhas $LPK3 strike)" "1"
-ok "italic in RTF"         "$(rtfhas $LPK3 '\i ')" "1"
-ok "list bullets stripped" "$("$CLI" --db "$DB" show $LPK3 --json | jq_ 'd["text"]' | grep -c '^- ')" "0"
-ESC=$(printf -- '1\\. literal not a list')
-EOUT3=$(printf '%s' "$ESC" | "$CLI" --db "$DB" write --markdown 2>&1)
-EPK3=$(echo "$EOUT3" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
-ok "escaped number stays plain" "$("$CLI" --db "$DB" show $EPK3 --json | jq_ 'd["text"]')" "1. literal not a list"
-ok "escaped number is not a list" "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'listtext') from ZJOURNALENTRYMO where Z_PK=$EPK3;")" "0"
+# Probe the capability rather than parsing help text: --dry-run writes
+# nothing, so this just asks whether this CLI understands --markdown at all.
+# The Python reference in CI does not, and skips the block.
+"$CLI" --db "$DB" write --body probe --markdown --dry-run >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  echo "T17 markdown rendering"
+  MD=$(printf '###### Reflect on today:\n1\\. first thing\n\n---\n\nIt was **hard**\\. See [my site](https://example.com)\n\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e \xf0\x9f\x9a\x95')
+  MDOUT=$(printf '%s' "$MD" | "$CLI" --db "$DB" write --title 'Day 9 \- Naoshima' --markdown 2>&1)
+  MDPK=$(echo "$MDOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+  MDTEXT=$("$CLI" --db "$DB" show $MDPK --json | jq_ 'd["text"]')
+  ok "heading marker stripped"  "$(printf '%s' "$MDTEXT" | grep -c '#')" "0"
+  ok "escapes removed"          "$(printf '%s' "$MDTEXT" | grep -c '\\\\\.')" "0"
+  ok "horizontal rule dropped"  "$(printf '%s' "$MDTEXT" | grep -cE '^---$')" "0"
+  ok "emphasis markers gone"    "$(printf '%s' "$MDTEXT" | grep -c '\*\*')" "0"
+  ok "heading text kept"        "$(printf '%s' "$MDTEXT" | grep -c 'Reflect on today:')" "1"
+  ok "link flattened"           "$(printf '%s' "$MDTEXT" | grep -c 'my site (https://example.com)')" "1"
+  JP=$(printf '\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e')
+  ok "unicode preserved"        "$(printf '%s' "$MDTEXT" | grep -cF "$JP")" "1"
+  ok "title de-escaped"         "$("$CLI" --db "$DB" show $MDPK --json | jq_ 'd["title"]')" "Day 9 - Naoshima"
+  ok "bold run in RTF"          "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'\\b')>0 from ZJOURNALENTRYMO where Z_PK=$MDPK;")" "1"
+  ok "bold font in RTF"         "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'Bold')>0 from ZJOURNALENTRYMO where Z_PK=$MDPK;")" "1"
+  LMD=$(printf -- '- alpha\n- beta\n\n1. one\n2. two\n\n~~gone~~ and *slanted*')
+  LOUT=$(printf '%s' "$LMD" | "$CLI" --db "$DB" write --markdown 2>&1)
+  LPK3=$(echo "$LOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+  rtfhas() { sqlite3 "$DB" "select instr(cast(ZTEXT as text),'$2')>0 from ZJOURNALENTRYMO where Z_PK=$1;"; }
+  ok "bulleted list in RTF"  "$(rtfhas $LPK3 disc)" "1"
+  ok "numbered list in RTF"  "$(rtfhas $LPK3 decimal)" "1"
+  ok "list markers emitted"  "$(rtfhas $LPK3 listtext)" "1"
+  ok "strikethrough in RTF"  "$(rtfhas $LPK3 strike)" "1"
+  ok "italic in RTF"         "$(rtfhas $LPK3 '\i ')" "1"
+  ok "list bullets stripped" "$("$CLI" --db "$DB" show $LPK3 --json | jq_ 'd["text"]' | grep -c '^- ')" "0"
+  ESC=$(printf -- '1\\. literal not a list')
+  EOUT3=$(printf '%s' "$ESC" | "$CLI" --db "$DB" write --markdown 2>&1)
+  EPK3=$(echo "$EOUT3" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+  ok "escaped number stays plain" "$("$CLI" --db "$DB" show $EPK3 --json | jq_ 'd["text"]')" "1. literal not a list"
+  ok "escaped number is not a list" "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'listtext') from ZJOURNALENTRYMO where Z_PK=$EPK3;")" "0"
 
-ESC2=$(printf -- 'a \\*literal\\* pair and \\_under\\_ too')
-E2OUT=$(printf '%s' "$ESC2" | "$CLI" --db "$DB" write --markdown 2>&1)
-E2PK=$(echo "$E2OUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
-ok "escaped emphasis stays literal" "$("$CLI" --db "$DB" show $E2PK --json | jq_ 'd["text"]')" "a *literal* pair and _under_ too"
-ok "escaped emphasis not italic"    "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'Italic') from ZJOURNALENTRYMO where Z_PK=$E2PK;")" "0"
-CRLF=$(printf 'first\r\nsecond\r\nthird')
-COUT=$(printf '%s' "$CRLF" | "$CLI" --db "$DB" write --markdown 2>&1)
-CPK=$(echo "$COUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
-ok "CRLF does not double-space" "$("$CLI" --db "$DB" show $CPK --json | jq_ 'd["text"]' | grep -c '^$')" "0"
-ok "CRLF keeps all lines"       "$("$CLI" --db "$DB" show $CPK --json | jq_ 'd["text"]' | grep -c .)" "3"
+  ESC2=$(printf -- 'a \\*literal\\* pair and \\_under\\_ too')
+  E2OUT=$(printf '%s' "$ESC2" | "$CLI" --db "$DB" write --markdown 2>&1)
+  E2PK=$(echo "$E2OUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+  ok "escaped emphasis stays literal" "$("$CLI" --db "$DB" show $E2PK --json | jq_ 'd["text"]')" "a *literal* pair and _under_ too"
+  ok "escaped emphasis not italic"    "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'Italic') from ZJOURNALENTRYMO where Z_PK=$E2PK;")" "0"
+  UOUT=$(printf 'foo__bar__baz and __real bold__' | "$CLI" --db "$DB" write --markdown 2>&1)
+  UPK=$(echo "$UOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+  ok "intraword __ stays literal" "$("$CLI" --db "$DB" show $UPK --json | jq_ 'd["text"]')" "foo__bar__baz and real bold"
 
-PLAINOUT=$("$CLI" --db "$DB" write --body '## not markdown mode' 2>&1)
-PLAINPK=$(echo "$PLAINOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
-ok "plain mode leaves text alone" "$("$CLI" --db "$DB" show $PLAINPK --json | jq_ 'd["text"]')" "## not markdown mode"
+  CRLF=$(printf 'first\r\nsecond\r\nthird')
+  COUT=$(printf '%s' "$CRLF" | "$CLI" --db "$DB" write --markdown 2>&1)
+  CPK=$(echo "$COUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+  ok "CRLF does not double-space" "$("$CLI" --db "$DB" show $CPK --json | jq_ 'd["text"]' | grep -c '^$')" "0"
+  ok "CRLF keeps all lines"       "$("$CLI" --db "$DB" show $CPK --json | jq_ 'd["text"]' | grep -c .)" "3"
+
+  PLAINOUT=$("$CLI" --db "$DB" write --body '## not markdown mode' 2>&1)
+  PLAINPK=$(echo "$PLAINOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+  ok "plain mode leaves text alone" "$("$CLI" --db "$DB" show $PLAINPK --json | jq_ 'd["text"]')" "## not markdown mode"
+
+else
+  echo "T17 markdown rendering (skipped: this CLI has no --markdown)"
+fi
 
 echo "T8 integrity"
 ok "integrity_check" "$(sqlite3 "$DB" 'PRAGMA integrity_check;' | head -1)" "ok"

--- a/tests/test_write.sh
+++ b/tests/test_write.sh
@@ -235,16 +235,29 @@ if [ "$NJ" -ge 2 ]; then
   JOUT=$("$CLI" --db "$DB" write --body "In the test journal." --journal "Test Journal" 2>&1)
   JPK=$(echo "$JOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
   ok "join row written" "$(sqlite3 "$DB" "select Z_6JOURNALS from Z_5JOURNALS where Z_5ENTRIES=$JPK;")" "$TJPK"
+  ok "custom journal queued for sync" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "0"
+  ok "custom journal version bumped" "$(sqlite3 "$DB" "select Z_OPT from ZJOURNALMO where Z_PK=$TJPK;")" "2"
   DOUT=$("$CLI" --db "$DB" write --body "In the default journal." 2>&1)
   DPK=$(echo "$DOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
   ok "default write has no join row" "$(sqlite3 "$DB" "select count(*) from Z_5JOURNALS where Z_5ENTRIES=$DPK;")" "0"
+  sqlite3 "$DB" "update ZJOURNALMO set ZISUPLOADEDTOCLOUD=1 where Z_PK=$TJPK;"
   "$CLI" --db "$DB" edit $DPK --journal "Test Journal" >/dev/null 2>&1
   ok "edit moves into journal" "$(sqlite3 "$DB" "select Z_6JOURNALS from Z_5JOURNALS where Z_5ENTRIES=$DPK;")" "$TJPK"
+  ok "move queues destination journal" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "0"
+  sqlite3 "$DB" "update ZJOURNALMO set ZISUPLOADEDTOCLOUD=1 where Z_PK=$TJPK;"
   "$CLI" --db "$DB" edit $DPK --journal 1 >/dev/null 2>&1
   ok "edit moves back to default (join row dropped)" "$(sqlite3 "$DB" "select count(*) from Z_5JOURNALS where Z_5ENTRIES=$DPK;")" "0"
+  ok "move queues source journal" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "0"
+  sqlite3 "$DB" "update ZJOURNALMO set ZISUPLOADEDTOCLOUD=1 where Z_PK=$TJPK;"
+  "$CLI" --db "$DB" sync-journals --dry-run >/dev/null 2>&1
+  ok "sync-journals dry-run is read-only" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "1"
+  "$CLI" --db "$DB" sync-journals >/dev/null 2>&1
+  ok "sync-journals repairs existing memberships" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "0"
   "$CLI" --db "$DB" write --body x --journal "No Such Journal" >/dev/null 2>&1
   ok "unknown journal rejected" "$?" "1"
+  sqlite3 "$DB" "update ZJOURNALMO set ZISUPLOADEDTOCLOUD=1 where Z_PK=$TJPK;"
   "$CLI" --db "$DB" delete $JPK --hard >/dev/null 2>&1
+  ok "hard delete queues former journal" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "0"
   "$CLI" --db "$DB" delete $DPK --hard >/dev/null 2>&1
 else
   echo "  SKIP  (seed has one journal)"
@@ -375,6 +388,9 @@ if [ $? -eq 0 ]; then
 # comment inside code
 ```')" "1"
   ok "render --plain works"           "$(printf '###### H' | "$CLI" render --plain)" "H"
+  ok "inline code kept verbatim"      "$(printf 'Use `**lit**` here' | "$CLI" render --plain)" "Use \`**lit**\` here"
+  ok "inline code not bolded"         "$(printf 'Use `**lit**` here' | "$CLI" render | grep -c 'Bold')" "0"
+  ok "code span does not block bold"  "$(printf '`x` and **b**' | "$CLI" render | grep -c 'Bold')" "1"
 
   UOUT=$(printf 'foo__bar__baz and __real bold__' | "$CLI" --db "$DB" write --markdown 2>&1)
   UPK=$(echo "$UOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')

--- a/tests/test_write.sh
+++ b/tests/test_write.sh
@@ -360,6 +360,22 @@ if [ $? -eq 0 ]; then
   E2PK=$(echo "$E2OUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
   ok "escaped emphasis stays literal" "$("$CLI" --db "$DB" show $E2PK --json | jq_ 'd["text"]')" "a *literal* pair and _under_ too"
   ok "escaped emphasis not italic"    "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'Italic') from ZJOURNALENTRYMO where Z_PK=$E2PK;")" "0"
+  # fix-text decides what to repair by comparing an entry's stored bytes with
+  # `render` output, so that equality is load-bearing.
+  rt_check() {
+    RTO=$(printf '%s' "$1" | "$CLI" --db "$DB" write --markdown 2>&1)
+    RTP=$(echo "$RTO" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+    STORED=$(sqlite3 "$DB" "select hex(ZTEXT) from ZJOURNALENTRYMO where Z_PK=$RTP;")
+    WANT=$(printf '%s' "$1" | "$CLI" render | xxd -p | tr -d '\n' | tr 'a-f' 'A-F')
+    [ "$STORED" = "$WANT" ] && echo 1 || echo 0
+  }
+  ok "render matches stored: italic"  "$(rt_check '*all italic here*')" "1"
+  ok "render matches stored: escaped" "$(rt_check '\*\*literal\*\* stays')" "1"
+  ok "render matches stored: fenced"  "$(rt_check '```
+# comment inside code
+```')" "1"
+  ok "render --plain works"           "$(printf '###### H' | "$CLI" render --plain)" "H"
+
   UOUT=$(printf 'foo__bar__baz and __real bold__' | "$CLI" --db "$DB" write --markdown 2>&1)
   UPK=$(echo "$UOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
   ok "intraword __ stays literal" "$("$CLI" --db "$DB" show $UPK --json | jq_ 'd["text"]')" "foo__bar__baz and real bold"

--- a/tests/test_write.sh
+++ b/tests/test_write.sh
@@ -390,6 +390,10 @@ if [ $? -eq 0 ]; then
   ok "render --plain works"           "$(printf '###### H' | "$CLI" render --plain)" "H"
   ok "inline code kept verbatim"      "$(printf 'Use `**lit**` here' | "$CLI" render --plain)" "Use \`**lit**\` here"
   ok "title keeps list-like text"     "$(printf '1. first' | "$CLI" render --inline)" "1. first"
+  ok "image syntax untouched"         "$(printf '![alt](https://e.com/i.png)' | "$CLI" render --plain)" '![alt](https://e.com/i.png)'
+  ok "real link still flattened"      "$(printf '[real](https://x.com)' | "$CLI" render --plain)" 'real (https://x.com)'
+  TOOUT=$("$CLI" --db "$DB" write --markdown --title 'Summary check' 2>&1)
+  ok "title-only summary not empty"   "$(printf '%s' "$TOOUT" | grep -c 'empty')" "0"
   ok "backslash before non-escapable" "$(printf 'C:\\Users\\omar' | "$CLI" render --plain)" 'C:\Users\omar'
   ok "unterminated code stays literal" "$(printf 'a `**x** b' | "$CLI" render --plain)" 'a `**x** b'
   ok "unterminated code not bolded"   "$(printf 'a `**x** b' | "$CLI" render | grep -c 'Bold')" "0"

--- a/tests/test_write.sh
+++ b/tests/test_write.sh
@@ -392,15 +392,19 @@ if [ $? -eq 0 ]; then
   ok "title keeps list-like text"     "$(printf '1. first' | "$CLI" render --inline)" "1. first"
   PUA=$(python3 -c 'import sys;sys.stdout.write("a\ue000b")')
   ok "private-use scalar survives"    "$(printf '%s' "$PUA" | "$CLI" render --plain)" "$PUA"
-  LLOUT=$(printf -- '- alpha\n- beta' | "$CLI" --db "$DB" write --markdown 2>&1)
-  LLPK=$(echo "$LLOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
-  ok "list length matches visible"    "$(sqlite3 "$DB" "select ZTEXTLENGTH from ZJOURNALENTRYMO where Z_PK=$LLPK;")" "10"
   "$CLI" --db "$DB" write --markdown --title '   ' >/dev/null 2>&1
   ok "blank title rejected"           "$?" "1"
   ok "title keeps rule-like text"     "$(printf -- '---' | "$CLI" render --inline)" "---"
   ok "title de-escapes"               "$(printf 'Day 9 \\- N' | "$CLI" render --inline)" "Day 9 - N"
-  ok "list plain omits markers"       "$(printf -- '- alpha\n- beta' | "$CLI" render --plain)" "alpha
-beta"
+  # Whether an RTF round trip keeps generated list markers differs by macOS
+  # release, so assert the invariant fix-text relies on -- that a stored entry
+  # reads back exactly as `render --plain` says it will -- not a literal.
+  LSRC=$(printf -- '- alpha\n- beta')
+  LWOUT=$(printf '%s' "$LSRC" | "$CLI" --db "$DB" write --markdown 2>&1)
+  LWPK=$(echo "$LWOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+  ok "stored list text matches render" "$("$CLI" --db "$DB" show $LWPK --json | jq_ 'd["text"]')" "$(printf '%s' "$LSRC" | "$CLI" render --plain)"
+  LWTEXT=$("$CLI" --db "$DB" show $LWPK --json | jq_ 'd["text"]')
+  ok "list length matches visible"    "$(sqlite3 "$DB" "select ZTEXTLENGTH from ZJOURNALENTRYMO where Z_PK=$LWPK;")" "$(printf '%s' "$LWTEXT" | wc -m | tr -d ' ')"
   TOUT=$("$CLI" --db "$DB" write --markdown --title 'Only a title' 2>&1)
   TPK=$(echo "$TOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
   ok "title-only entry allowed"       "$("$CLI" --db "$DB" show $TPK --json | jq_ 'd["title"]')" "Only a title"

--- a/tests/test_write.sh
+++ b/tests/test_write.sh
@@ -332,23 +332,34 @@ ok "link flattened"           "$(printf '%s' "$MDTEXT" | grep -c 'my site (https
 JP=$(printf '\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e')
 ok "unicode preserved"        "$(printf '%s' "$MDTEXT" | grep -cF "$JP")" "1"
 ok "title de-escaped"         "$("$CLI" --db "$DB" show $MDPK --json | jq_ 'd["title"]')" "Day 9 - Naoshima"
-ok "bold run in RTF"          "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'\\b') > 0 from ZJOURNALENTRYMO where Z_PK=$MDPK;")" "1"
-ok "bold font in RTF"         "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'Bold') > 0 from ZJOURNALENTRYMO where Z_PK=$MDPK;")" "1"
+ok "bold run in RTF"          "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'\\b')>0 from ZJOURNALENTRYMO where Z_PK=$MDPK;")" "1"
+ok "bold font in RTF"         "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'Bold')>0 from ZJOURNALENTRYMO where Z_PK=$MDPK;")" "1"
 LMD=$(printf -- '- alpha\n- beta\n\n1. one\n2. two\n\n~~gone~~ and *slanted*')
 LOUT=$(printf '%s' "$LMD" | "$CLI" --db "$DB" write --markdown 2>&1)
 LPK3=$(echo "$LOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
-LRTF=$(sqlite3 "$DB" "select cast(ZTEXT as text) from ZJOURNALENTRYMO where Z_PK=$LPK3;")
-ok "bulleted list in RTF"  "$(printf '%s' "$LRTF" | grep -c 'disc')" "1"
-ok "numbered list in RTF"  "$(printf '%s' "$LRTF" | grep -c 'decimal')" "1"
-ok "list markers emitted"  "$(printf '%s' "$LRTF" | grep -q 'listtext' && echo 1 || echo 0)" "1"
-ok "strikethrough in RTF"  "$(printf '%s' "$LRTF" | grep -c 'strike')" "1"
-ok "italic in RTF"         "$(printf '%s' "$LRTF" | grep -cE '\\i[ 0]')" "1"
+rtfhas() { sqlite3 "$DB" "select instr(cast(ZTEXT as text),'$2')>0 from ZJOURNALENTRYMO where Z_PK=$1;"; }
+ok "bulleted list in RTF"  "$(rtfhas $LPK3 disc)" "1"
+ok "numbered list in RTF"  "$(rtfhas $LPK3 decimal)" "1"
+ok "list markers emitted"  "$(rtfhas $LPK3 listtext)" "1"
+ok "strikethrough in RTF"  "$(rtfhas $LPK3 strike)" "1"
+ok "italic in RTF"         "$(rtfhas $LPK3 '\i ')" "1"
 ok "list bullets stripped" "$("$CLI" --db "$DB" show $LPK3 --json | jq_ 'd["text"]' | grep -c '^- ')" "0"
 ESC=$(printf -- '1\\. literal not a list')
 EOUT3=$(printf '%s' "$ESC" | "$CLI" --db "$DB" write --markdown 2>&1)
 EPK3=$(echo "$EOUT3" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
 ok "escaped number stays plain" "$("$CLI" --db "$DB" show $EPK3 --json | jq_ 'd["text"]')" "1. literal not a list"
 ok "escaped number is not a list" "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'listtext') from ZJOURNALENTRYMO where Z_PK=$EPK3;")" "0"
+
+ESC2=$(printf -- 'a \\*literal\\* pair and \\_under\\_ too')
+E2OUT=$(printf '%s' "$ESC2" | "$CLI" --db "$DB" write --markdown 2>&1)
+E2PK=$(echo "$E2OUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+ok "escaped emphasis stays literal" "$("$CLI" --db "$DB" show $E2PK --json | jq_ 'd["text"]')" "a *literal* pair and _under_ too"
+ok "escaped emphasis not italic"    "$(sqlite3 "$DB" "select instr(cast(ZTEXT as text),'Italic') from ZJOURNALENTRYMO where Z_PK=$E2PK;")" "0"
+CRLF=$(printf 'first\r\nsecond\r\nthird')
+COUT=$(printf '%s' "$CRLF" | "$CLI" --db "$DB" write --markdown 2>&1)
+CPK=$(echo "$COUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+ok "CRLF does not double-space" "$("$CLI" --db "$DB" show $CPK --json | jq_ 'd["text"]' | grep -c '^$')" "0"
+ok "CRLF keeps all lines"       "$("$CLI" --db "$DB" show $CPK --json | jq_ 'd["text"]' | grep -c .)" "3"
 
 PLAINOUT=$("$CLI" --db "$DB" write --body '## not markdown mode' 2>&1)
 PLAINPK=$(echo "$PLAINOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')

--- a/tests/test_write.sh
+++ b/tests/test_write.sh
@@ -389,6 +389,15 @@ if [ $? -eq 0 ]; then
 ```')" "1"
   ok "render --plain works"           "$(printf '###### H' | "$CLI" render --plain)" "H"
   ok "inline code kept verbatim"      "$(printf 'Use `**lit**` here' | "$CLI" render --plain)" "Use \`**lit**\` here"
+  ok "title keeps list-like text"     "$(printf '1. first' | "$CLI" render --inline)" "1. first"
+  ok "title keeps rule-like text"     "$(printf -- '---' | "$CLI" render --inline)" "---"
+  ok "title de-escapes"               "$(printf 'Day 9 \\- N' | "$CLI" render --inline)" "Day 9 - N"
+  ok "list plain omits markers"       "$(printf -- '- alpha\n- beta' | "$CLI" render --plain)" "alpha
+beta"
+  TOUT=$("$CLI" --db "$DB" write --markdown --title 'Only a title' 2>&1)
+  TPK=$(echo "$TOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+  ok "title-only entry allowed"       "$("$CLI" --db "$DB" show $TPK --json | jq_ 'd["title"]')" "Only a title"
+  ok "title-only stored list-title"   "$("$CLI" --db "$DB" write --markdown --title '1. first' 2>&1 | grep -c 'Created entry')" "1"
   ok "inline code not bolded"         "$(printf 'Use `**lit**` here' | "$CLI" render | grep -c 'Bold')" "0"
   ok "code span does not block bold"  "$(printf '`x` and **b**' | "$CLI" render | grep -c 'Bold')" "1"
 

--- a/tests/test_write.sh
+++ b/tests/test_write.sh
@@ -390,6 +390,13 @@ if [ $? -eq 0 ]; then
   ok "render --plain works"           "$(printf '###### H' | "$CLI" render --plain)" "H"
   ok "inline code kept verbatim"      "$(printf 'Use `**lit**` here' | "$CLI" render --plain)" "Use \`**lit**\` here"
   ok "title keeps list-like text"     "$(printf '1. first' | "$CLI" render --inline)" "1. first"
+  PUA=$(python3 -c 'import sys;sys.stdout.write("a\ue000b")')
+  ok "private-use scalar survives"    "$(printf '%s' "$PUA" | "$CLI" render --plain)" "$PUA"
+  LLOUT=$(printf -- '- alpha\n- beta' | "$CLI" --db "$DB" write --markdown 2>&1)
+  LLPK=$(echo "$LLOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
+  ok "list length matches visible"    "$(sqlite3 "$DB" "select ZTEXTLENGTH from ZJOURNALENTRYMO where Z_PK=$LLPK;")" "10"
+  "$CLI" --db "$DB" write --markdown --title '   ' >/dev/null 2>&1
+  ok "blank title rejected"           "$?" "1"
   ok "title keeps rule-like text"     "$(printf -- '---' | "$CLI" render --inline)" "---"
   ok "title de-escapes"               "$(printf 'Day 9 \\- N' | "$CLI" render --inline)" "Day 9 - N"
   ok "list plain omits markers"       "$(printf -- '- alpha\n- beta' | "$CLI" render --plain)" "alpha


### PR DESCRIPTION
## Why

Day One imports had two fidelity problems:

1. Journal renders RTF, not Markdown, so headings, lists, emphasis, and Day One escapes appeared literally.
2. Custom-journal membership was stored locally, but the custom journal record was not queued for CloudKit upload. Entries looked correctly categorized on the Mac while another device placed them in the default Journal.

## What

- Add `--markdown` and `render` to convert Day One Markdown into Journal-native rich text.
- Add `--body-rtf` for callers with prepared RTF.
- Add `fix-text` to safely repair earlier imports by comparing their stored bytes with freshly rendered output.
- Mark affected custom journal records unsynced whenever membership changes.
- Add `sync-journals` to repair memberships created by journal-cli 1.0.6 or earlier without rewriting entries or media.
- Keep the Swift CLI and Python reference behavior aligned for journal membership repair.

## Verification

- Release Swift build passed.
- Fixture-backed Swift suite: 146 passed, 0 failed.
- Fixture-backed Python reference suite: 115 passed, 0 failed.
- Independent review found no blocker, should-fix, or nit findings.
- `git diff --check origin/main` passed.

The live membership repair is run separately against the local Journal database, followed by launching Journal so its sync engine can upload the corrected custom-journal records.