### PR TITLE
Use native Journal moves for synced memberships

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,11 @@ journal-cli write --live --body "Read this" --link https://example.com --link-ti
 # markdown -> Journal's own rich text (bold, italic, lists, strikethrough)
 journal-cli write --live --markdown --body-file entry.md
 
-# target a journal; link photos back to the Photos library
+# stage in a Mac-local journal; link photos back to the Photos library
 journal-cli write --live --journal "Travel" --body "..." --media IMG_0079.JPG --photos-link
 
-# repair memberships written by journal-cli 1.0.6 or earlier that looked right
-# on this Mac but appeared in the default Journal on another device
-journal-cli sync-journals --live
+# audit staged memberships and print the native Journal.app finalization steps
+journal-cli sync-journals --journal "Travel"
 ```
 
 ### Editing
@@ -120,7 +119,7 @@ journal-cli edit 103 --live --lat 47.6 --lon -122.3 --place Home   # set/replace
 journal-cli edit 103 --live --add-media c.heic --add-link https://example.org
 journal-cli edit 103 --live --remove-media 700                     # ids shown by `show`
 journal-cli edit 103 --live --clear-location --no-bookmark
-journal-cli edit 103 --live --journal "Travel"                     # move journals
+journal-cli edit 103 --live --journal "Travel"                     # stage an imported entry
 ```
 
 ### Deleting
@@ -214,7 +213,7 @@ engine uploads them all to CloudKit — including the attachment files — and a
 delete/restore round trip propagates. The read pipeline has been swept over an
 entire real store: every entry row and all ~700 asset metadata blobs parse.
 
-The test suite (`tests/test_write.sh`, 146 assertions) runs the whole command
+The test suite (`tests/test_write.sh`) runs the whole command
 surface against a disposable copy of a store — argument guards, insert
 bookkeeping, RTF round-trips, location metadata, media file layout, Live Photo
 pairing, Photos linkage, journal targeting, link assets, the delete/restore
@@ -244,7 +243,7 @@ the sync cache.)
 | asset metadata | one version byte `0x01` + JSON; `0x02` + UUID = Core Data external storage in `.moments_SUPPORT/_EXTERNAL_DATA/` |
 | links | base64 `NSKeyedArchiver`-archived `LPLinkMetadata` inside the asset metadata |
 | audio | asset metadata carries duration, waveform, and a word-level transcript |
-| journals | `ZJOURNALMO` (names live in each journal's CRDT blob) + `Z_5JOURNALS` join; membership changes also mark the custom journal unsynced so its record is re-uploaded |
+| journals | `ZJOURNALMO` (names live in each journal's merge blob) + `Z_5JOURNALS` join; direct join changes are Mac-local until Journal.app performs a native move and authors the per-entry merge data |
 | new-row bookkeeping | fresh `Z_PK`, bumped `Z_PRIMARYKEY.Z_MAX`, 16-byte UUID `ZID`, `ZISUPLOADEDTOCLOUD=0` — Journal's sync engine adopts the row and uploads it |
 
 ### The CRDT limitation
@@ -262,8 +261,8 @@ entry whose text was typed in the app. Consequences:
 - **`edit` refuses to rewrite text on CRDT-bearing entries** unless `--force`
   is passed: rewriting only the RTF leaves the CRDT holding the old text with
   authoritative history, and sync can revert or duplicate the edit. Location,
-  media, links, date, bookmark and journal moves are safe on any entry — none
-  of that state lives in the CRDT (verified across a real library).
+  media, links, date, and bookmark remain editable. Journal moves on entries
+  with merge data must be performed in Journal.app so they sync correctly.
 - **CLI-written entries have no CRDT.** Journal renders and syncs them fine,
   but a simultaneous edit on two devices may not merge like an app-authored
   entry would.

--- a/reference/journal-cli.py
+++ b/reference/journal-cli.py
@@ -585,19 +585,6 @@ def resolve_journal(conn, sel):
     die(f"journal name {sel!r} is ambiguous; use the id: " +
         ", ".join(str(j["pk"]) for j in hits))
 
-def journal_pks_for_entry(conn, entry_pk):
-    return [r[0] for r in conn.execute(
-        "select Z_6JOURNALS from Z_5JOURNALS where Z_5ENTRIES=?", (entry_pk,))]
-
-def mark_journals_unsynced(conn, journal_pks):
-    """Queue changed custom-journal membership records for CloudKit upload."""
-    for pk in set(journal_pks):
-        conn.execute("""update ZJOURNALMO
-                        set ZISUPLOADEDTOCLOUD=0, Z_OPT=coalesce(Z_OPT,0)+1
-                        where Z_PK=?
-                          and not (ZMERGEABLEATTRIBUTES is null and ZSORTCATEGORY < 0)""",
-                     (pk,))
-
 def cmd_journals(a):
     with Snapshot() as c:
         rows = journal_rows(c)
@@ -706,6 +693,7 @@ def cmd_write(a):
         if a.journal: bits.append(f"journal {a.journal!r}")
         print(f"DRY RUN: would create entry ({', '.join(bits) or 'empty'}) dated {when:%Y-%m-%d %H:%M}. Nothing written.")
         return
+    staged = False
     with Live(allow_live_default=a.live, accept_risk=a.accept_risk) as conn:
         ent, pk = next_pk(conn, "entry")
         conn.execute("""
@@ -776,7 +764,7 @@ def cmd_write(a):
             if not jdefault:
                 conn.execute("insert or ignore into Z_5JOURNALS (Z_5ENTRIES, Z_6JOURNALS) values (?,?)",
                              (pk, jpk))
-                mark_journals_unsynced(conn, [jpk])
+                staged = True
         # no --journal: the entry lands in the default journal implicitly (no join
         # row), matching how most native entries are stored
 
@@ -787,6 +775,10 @@ def cmd_write(a):
     if has_loc: bits.append(f"location {a.lat:.5f},{a.lon:.5f}")
     if a.journal: bits.append(f"journal {a.journal!r}")
     print(f"Created entry {pk} ({', '.join(bits) or 'empty'}) dated {when:%Y-%m-%d %H:%M}.")
+    if staged:
+        print("warning: this is a Mac-local staging membership. "
+              "Run `sync-journals --journal NAME` for the native Journal.app "
+              "steps required to sync it to other devices.", file=sys.stderr)
 
 def ordering_append(conn, pk, new_uuids):
     """Append asset UUIDs to ZASSETORDERING, preserving existing order."""
@@ -860,6 +852,7 @@ def cmd_edit(a):
         print(f"DRY RUN: would update entry {a.id}. Nothing written.")
         return
 
+    staged = False
     with Live(allow_live_default=a.live, accept_risk=a.accept_risk) as conn:
         row = conn.execute("""select Z_PK, ZID, ZMERGEABLEATTRIBUTES
                               from ZJOURNALENTRYMO where Z_PK=?""", (a.id,)).fetchone()
@@ -871,6 +864,9 @@ def cmd_edit(a):
                 "  of the text). Editing ZTEXT alone can be reverted or duplicated on sync.\n"
                 "  Change location/media/date/bookmark freely, edit the text in Journal.app,\n"
                 "  or pass --force to write ZTEXT anyway.")
+        if a.journal and row["ZMERGEABLEATTRIBUTES"] is not None:
+            die(f"entry {a.id} already has Journal merge attributes. A direct journal move\n"
+                "  would be Mac-local and can be reverted by iCloud. Move it in Journal.app.")
 
         sets, vals = [], []
         if body is not None:
@@ -943,12 +939,11 @@ def cmd_edit(a):
 
         if a.journal:
             jpk, jname, jdefault = resolve_journal(conn, a.journal)
-            old_jpks = journal_pks_for_entry(conn, a.id)
             conn.execute("delete from Z_5JOURNALS where Z_5ENTRIES=?", (a.id,))
             if not jdefault:
                 conn.execute("insert into Z_5JOURNALS (Z_5ENTRIES, Z_6JOURNALS) values (?,?)",
                              (a.id, jpk))
-            mark_journals_unsynced(conn, old_jpks + ([] if jdefault else [jpk]))
+                staged = True
 
     bits = []
     if body is not None: bits.append("body")
@@ -962,6 +957,10 @@ def cmd_edit(a):
     if a.add_link: bits.append("1 link added")
     if a.journal: bits.append(f"moved to journal {a.journal!r}")
     print(f"Updated entry {a.id} ({', '.join(bits)}).")
+    if staged:
+        print("warning: this is a Mac-local staging membership. "
+              "Run `sync-journals --journal NAME` for the native Journal.app "
+              "steps required to sync it to other devices.", file=sys.stderr)
 
 def cmd_delete(a):
     if a.dry_run:
@@ -980,7 +979,6 @@ def cmd_delete(a):
                 "  sync (verified). Use a soft delete (no --hard), delete it in\n"
                 "  Journal.app, or pass --force if you accept the resurrection risk.")
         if a.hard:
-            old_jpks = journal_pks_for_entry(conn, a.id)
             apks = [r[0] for r in conn.execute(
                 "select Z_PK from ZJOURNALENTRYASSETMO where ZENTRY=?", (a.id,))]
             for apk in apks:
@@ -988,7 +986,6 @@ def cmd_delete(a):
             conn.execute("delete from ZJOURNALENTRYASSETMO where ZENTRY=?", (a.id,))
             conn.execute("delete from Z_5JOURNALS where Z_5ENTRIES=?", (a.id,))
             conn.execute("delete from ZJOURNALENTRYMO where Z_PK=?", (a.id,))
-            mark_journals_unsynced(conn, old_jpks)
             eu = u_str(row["ZID"])
             if eu:
                 d = os.path.join(attach_dir(), eu)
@@ -1063,14 +1060,12 @@ def cmd_empty(a):
             if r["ZISUPLOADEDTOCLOUD"] and not a.force:
                 skipped += 1; continue
             eu = u_str(r["ZID"])
-            old_jpks = journal_pks_for_entry(conn, r["Z_PK"])
             for (apk,) in conn.execute("select Z_PK from ZJOURNALENTRYASSETMO where ZENTRY=?",
                                        (r["Z_PK"],)):
                 conn.execute("delete from ZJOURNALENTRYASSETFILEATTACHMENTMO where ZASSET=?", (apk,))
             conn.execute("delete from ZJOURNALENTRYASSETMO where ZENTRY=?", (r["Z_PK"],))
             conn.execute("delete from Z_5JOURNALS where Z_5ENTRIES=?", (r["Z_PK"],))
             conn.execute("delete from ZJOURNALENTRYMO where Z_PK=?", (r["Z_PK"],))
-            mark_journals_unsynced(conn, old_jpks)
             if eu:
                 d = os.path.join(attach_dir(), eu)
                 if os.path.isdir(d): shutil.rmtree(d, ignore_errors=True)
@@ -1087,23 +1082,38 @@ def cmd_sync_journals(a):
         if a.journal:
             pk, name, is_default = resolve_journal(conn, a.journal)
             if is_default:
-                die("the default journal has no custom membership record to sync")
+                die("the default journal has no custom membership to audit")
             return [{"pk": pk, "name": name, "default": False}]
         return [j for j in journal_rows(conn) if not j["default"]]
 
-    if a.dry_run:
-        with Snapshot() as conn:
-            rows = selected_rows(conn)
-        print(f"DRY RUN: would queue {len(rows)} custom journal"
-              f"{'s' if len(rows) != 1 else ''} for membership re-upload. Nothing written.")
-        return
-
-    with Live(allow_live_default=a.live, accept_risk=a.accept_risk) as conn:
+    with Snapshot() as conn:
         rows = selected_rows(conn)
-        mark_journals_unsynced(conn, [j["pk"] for j in rows])
-    print(f"Queued {len(rows)} custom journal{'s' if len(rows) != 1 else ''} "
-          "for membership re-upload. Open Journal.app to sync the corrected "
-          "memberships to other devices.")
+        repairs = []
+        for j in rows:
+            count = conn.execute("""select count(*) from Z_5JOURNALS j
+                                    join ZJOURNALENTRYMO e on e.Z_PK=j.Z_5ENTRIES
+                                    where j.Z_6JOURNALS=?
+                                      and e.ZMERGEABLEATTRIBUTES is null
+                                      and coalesce(e.ZISFULLYREMOVED,0)=0
+                                      and coalesce(e.ZRECENTLYDELETED,0)=0""",
+                                 (j["pk"],)).fetchone()[0]
+            if count:
+                repairs.append((j, count))
+    if not repairs:
+        print("No Mac-local custom-journal memberships found.")
+        return
+    print("Mac-local memberships that require finalization in Journal.app:")
+    for journal, count in repairs:
+        print(f"  {journal['name']}: {count} entr{'y' if count == 1 else 'ies'}")
+    print("""
+Direct database relationships do not contain Journal's per-entry iCloud merge data.
+For each journal above:
+  1. In Journal.app, create a new final journal with a different name.
+  2. Open the staging journal, then choose Select Entries > Select All.
+  3. Choose Move / Choose Journals and select the new final journal.
+  4. Wait until the staging journal shows 0 entries and iCloud finishes syncing.
+
+This command is read-only. --live and --dry-run are accepted for compatibility.""")
 
 def cmd_sandbox(a):
     """Seed a throwaway store. --from lets tests run off a backup without FDA."""
@@ -1234,7 +1244,7 @@ def main():
     em.add_argument("--live", action="store_true"); em.set_defaults(func=cmd_empty)
 
     sj = sub.add_parser("sync-journals",
-                        help="re-upload custom-journal memberships after a direct-store import")
+                        help="audit Mac-local memberships and print native repair steps")
     sj.add_argument("--journal", help="journal name or id (default: all custom journals)")
     sj.add_argument("--dry-run", dest="dry_run", action="store_true")
     sj.add_argument("--accept-risk", dest="accept_risk", action="store_true")

--- a/skills/dayone-import/SKILL.md
+++ b/skills/dayone-import/SKILL.md
@@ -86,20 +86,28 @@ journal-cli --db "$DB" journals --json      # verify counts, then spot-check
 
 Then replay the identical command without `--target-db`.
 
-Imports made with journal-cli 1.0.6 or earlier can look correctly categorized
-on the Mac while another device places every imported entry in the default
-Journal. Repair those existing memberships once with:
+`--into` is a staging journal on this Mac. Direct Core Data relationships do
+not create Journal's per-entry iCloud merge data, so they can look correct on
+the Mac while another device places every imported entry in the default
+Journal. Audit the staging journal with:
 
 ```sh
-journal-cli sync-journals --dry-run
-journal-cli sync-journals --live
+journal-cli sync-journals --journal "Day One - Photography"
 ```
 
-The repair queues the custom journal records for re-upload; it does not rewrite
-the imported entries or their media.
+Then use the required native finalization workflow:
 
-- **The target journal must already exist** in Journal.app — create it there
-  first (journal-cli cannot create journals).
+1. In Journal.app, create a new final journal with a different name, such as
+   `Photography`.
+2. Open the staging journal, choose **Select Entries**, then **Select All**.
+3. Choose **Move / Choose Journals** and select the new final journal.
+4. Wait until the staging journal shows 0 entries and iCloud finishes syncing.
+
+The native move creates the merge data that syncs membership to iPhone and
+other devices. `sync-journals` is a read-only audit and instruction command.
+
+- **The staging journal must already exist** in Journal.app. Give it a name
+  distinct from the final journal, for example `Day One - Photography`.
 - **Quit Journal.app** before a live run; `journal-cli` refuses while it runs.
 - **Resumable.** Progress is kept in `~/.local/state/dayone-import/<journal>.json`
   keyed by Day One UUID, so a re-run skips what already landed and never
@@ -213,9 +221,10 @@ Always `--dry-run` first; it prints every rename it intends to make.
 
 ## Sharp edges
 
-- **Confirm the target journal with the user before a live import.** Entries
-  land in a real, syncing journal; there is no bulk undo beyond
-  `journal-cli delete` per entry.
+- **Confirm the staging journal with the user before a live import.** Entries
+  land in the real store and sync, but the staging membership remains Mac-local
+  until the user completes the native finalization move. There is no bulk undo
+  beyond `journal-cli delete` per entry.
 - Photos are copied and resized into Journal's store and then **upload to
   iCloud**. Say roughly how much data that is before starting.
 - Day One may be mid-sync; its entry counts can move between runs. Re-run

--- a/skills/dayone-import/scripts/dayone-import.py
+++ b/skills/dayone-import/scripts/dayone-import.py
@@ -205,7 +205,12 @@ def cmd_import(args):
 
     print("\nWrote %d, failed %d. State: %s" % (ok, fail, state_path))
     if not args.dry_run and live:
-        print("Launch Journal.app to let it sync the new entries to iCloud.")
+        print("\nThe entries are in Mac-local staging journal %r." % target)
+        print("To sync that journal membership to iPhone and other devices:")
+        print("  1. In Journal.app, create a new final journal with a different name.")
+        print("  2. Open %r, then choose Select Entries > Select All." % target)
+        print("  3. Choose Move / Choose Journals and select the new final journal.")
+        print("  4. Wait until %r shows 0 entries and iCloud finishes syncing." % target)
 
 
 # journal-cli snapshots the whole store before every live write; across a

--- a/skills/journal-cli/SKILL.md
+++ b/skills/journal-cli/SKILL.md
@@ -47,9 +47,9 @@ journal-cli write --live --media a.heic b.mov          # photos auto-resize
 journal-cli write --live --live-photo IMG.heic IMG.mov # image+video pair
 journal-cli write --live --lat N --lon N --place P --city C
 journal-cli write --live --link URL --link-title T
-journal-cli write --live --journal "Name" ...          # non-default journal
+journal-cli write --live --journal "Name" ...          # Mac-local staging journal
 journal-cli edit <id> --live [same flags; --add-media/--add-link/--remove-media ID/--clear-location/--journal N]
-journal-cli sync-journals --live                       # repair pre-1.0.7 cross-device memberships
+journal-cli sync-journals --journal "Name"             # audit and show native finalization steps
 journal-cli delete <id> --live                         # soft; syncs properly
 journal-cli restore <id> --live
 ```
@@ -89,9 +89,11 @@ for anything experimental; replay with `--live` once it looks right.
   entries — it propagates.
 - If the user has a designated test journal, write there
   (`--journal "<name>"`); check `journal-cli journals --json` first.
-- If custom-journal entries look correct on the Mac but appear in the default
-  Journal on another device, run `sync-journals --dry-run` and then
-  `sync-journals --live`. This queues each custom journal record for re-upload;
-  it does not rewrite every entry.
+- `--journal` writes a Mac-local staging relationship. It does not construct
+  Journal's per-entry iCloud merge data. To sync membership to other devices,
+  run `sync-journals --journal "<staging name>"` and follow its native workflow:
+  create a differently named final journal in Journal.app, select all entries
+  in the staging journal, move them to the final journal, and wait for staging
+  to reach 0. The command is read-only.
 - Dates print in the machine's local timezone; a stale or invalid `TZ` env
   var in your shell will skew displayed times, not stored ones.

--- a/swift/Sources/journal-cli/Model.swift
+++ b/swift/Sources/journal-cli/Model.swift
@@ -172,26 +172,6 @@ func resolveJournal(_ db: DB, _ sel: String) -> JournalRow {
         + hits.map { String($0.pk) }.joined(separator: ", "))
 }
 
-/// Journal syncs custom-journal membership from the JournalMO record, not from
-/// the entry record. Any join-table change therefore has to dirty the affected
-/// custom journal as well as the entry; otherwise the relationship is local-only
-/// and other devices place the entry in the default journal.
-func markJournalsUnsynced(_ db: DB, _ journalPKs: [Int64]) {
-    let pks = Array(Set(journalPKs))
-    for pk in pks {
-        db.exec("""
-            update ZJOURNALMO
-            set ZISUPLOADEDTOCLOUD=0, Z_OPT=coalesce(Z_OPT,0)+1
-            where Z_PK=? and not (ZMERGEABLEATTRIBUTES is null and ZSORTCATEGORY < 0)
-            """, [pk])
-    }
-}
-
-func journalPKsForEntry(_ db: DB, _ entryPK: Int64) -> [Int64] {
-    db.query("select Z_6JOURNALS from Z_5JOURNALS where Z_5ENTRIES=?", [entryPK])
-        .compactMap { $0.i("Z_6JOURNALS") }
-}
-
 // ---------------------------------------------------------------- write helpers
 
 func nextPK(_ db: DB, _ entityName: String) -> (ent: Int64, pk: Int64) {

--- a/swift/Sources/journal-cli/WriteCommands.swift
+++ b/swift/Sources/journal-cli/WriteCommands.swift
@@ -40,6 +40,14 @@ private func readBody(_ a: Args) -> String? {
     return nil
 }
 
+private func warnStagingJournal() {
+    FileHandle.standardError.write(
+        ("warning: this is a Mac-local staging membership. "
+         + "Run `sync-journals --journal NAME` for the native Journal.app "
+         + "steps required to sync that membership to other devices.\n")
+            .data(using: .utf8)!)
+}
+
 // Render Markdown the way `write --markdown` would, without touching a store.
 // Lets callers compare an entry's stored text against what it *should* be,
 // which is exact where sniffing for leftover syntax is guesswork.
@@ -102,7 +110,9 @@ func cmdWrite(_ a: Args) {
         print("DRY RUN: would create entry (\(bits.isEmpty ? "empty" : bits.joined(separator: ", "))) dated \(f.string(from: when)). Nothing written.")
         return
     }
-    let pk: Int64 = withLive(allowLiveDefault: a.has("--live"), acceptRisk: a.has("--accept-risk")) { db in
+    let created: (pk: Int64, staged: Bool) = withLive(
+        allowLiveDefault: a.has("--live"), acceptRisk: a.has("--accept-risk")
+    ) { db in
         let (ent, pk) = nextPK(db, "JournalEntryMO")
         db.exec("""
             insert into ZJOURNALENTRYMO
@@ -182,10 +192,10 @@ func cmdWrite(_ a: Args) {
             if !j.isDefault {
                 db.exec("insert or ignore into Z_5JOURNALS (Z_5ENTRIES, Z_6JOURNALS) values (?,?)",
                         [pk, j.pk])
-                markJournalsUnsynced(db, [j.pk])
+                return (pk, true)
             }
         }
-        return pk
+        return (pk, false)
     }
 
     var bits: [String] = []
@@ -197,11 +207,12 @@ func cmdWrite(_ a: Args) {
     if hasLoc { bits.append(String(format: "location %.5f,%.5f", lat!, lon!)) }
     if let j = a.value("--journal") { bits.append("journal '\(j)'") }
     let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd HH:mm"
-    print("Created entry \(pk) (\(bits.isEmpty ? "empty" : bits.joined(separator: ", "))) dated \(f.string(from: when)).")
+    print("Created entry \(created.pk) (\(bits.isEmpty ? "empty" : bits.joined(separator: ", "))) dated \(f.string(from: when)).")
     if a.has("--live") {
         FileHandle.standardError.write(
             "Marked unsynced; Journal.app should upload it on next launch.\n".data(using: .utf8)!)
     }
+    if created.staged { warnStagingJournal() }
 }
 
 func cmdEdit(_ a: Args) {
@@ -235,6 +246,7 @@ func cmdEdit(_ a: Args) {
         return
     }
     var removed = 0
+    var staged = false
     withLive(allowLiveDefault: a.has("--live"), acceptRisk: a.has("--accept-risk")) { db in
         guard let row = db.one("""
             select Z_PK, ZID, ZMERGEABLEATTRIBUTES from ZJOURNALENTRYMO where Z_PK=?
@@ -246,6 +258,10 @@ func cmdEdit(_ a: Args) {
                 + "  of the text). Editing ZTEXT alone can be reverted or duplicated on sync.\n"
                 + "  Change location/media/date/bookmark freely, edit the text in Journal.app,\n"
                 + "  or pass --force to write ZTEXT anyway.")
+        }
+        if a.value("--journal") != nil, row.b("ZMERGEABLEATTRIBUTES") != nil {
+            die("entry \(pk) already has Journal merge attributes. A direct journal move\n"
+                + "  would be Mac-local and can be reverted by iCloud. Move it in Journal.app.")
         }
 
         var sets: [String] = []
@@ -338,12 +354,11 @@ func cmdEdit(_ a: Args) {
 
         if let jsel = a.value("--journal") {
             let j = resolveJournal(db, jsel)
-            let oldJournalPKs = journalPKsForEntry(db, pk)
             db.exec("delete from Z_5JOURNALS where Z_5ENTRIES=?", [pk])
             if !j.isDefault {
                 db.exec("insert into Z_5JOURNALS (Z_5ENTRIES, Z_6JOURNALS) values (?,?)", [pk, j.pk])
+                staged = true
             }
-            markJournalsUnsynced(db, oldJournalPKs + (j.isDefault ? [] : [j.pk]))
         }
     }
 
@@ -359,6 +374,7 @@ func cmdEdit(_ a: Args) {
     if addLink != nil { bits.append("1 link added") }
     if let j = a.value("--journal") { bits.append("moved to journal '\(j)'") }
     print("Updated entry \(pk) (\(bits.joined(separator: ", "))).")
+    if staged { warnStagingJournal() }
 }
 
 func cmdDelete(_ a: Args) {
@@ -381,7 +397,6 @@ func cmdDelete(_ a: Args) {
                 + "  Journal.app, or pass --force if you accept the resurrection risk.")
         }
         if a.has("--hard") {
-            let oldJournalPKs = journalPKsForEntry(db, pk)
             let apks = db.query("select Z_PK from ZJOURNALENTRYASSETMO where ZENTRY=?", [pk])
                 .compactMap { $0.i("Z_PK") }
             for apk in apks {
@@ -390,7 +405,6 @@ func cmdDelete(_ a: Args) {
             db.exec("delete from ZJOURNALENTRYASSETMO where ZENTRY=?", [pk])
             db.exec("delete from Z_5JOURNALS where Z_5ENTRIES=?", [pk])
             db.exec("delete from ZJOURNALENTRYMO where Z_PK=?", [pk])
-            markJournalsUnsynced(db, oldJournalPKs)
             if let eu = uString(row.b("ZID")) {
                 try? FileManager.default.removeItem(atPath: attachDir() + "/" + eu)
             }
@@ -447,7 +461,6 @@ func cmdEmpty(_ a: Args) {
             """) {
             if r.flag("ZISUPLOADEDTOCLOUD") && !a.has("--force") { skipped += 1; continue }
             let pk = r.i("Z_PK") ?? 0
-            let oldJournalPKs = journalPKsForEntry(db, pk)
             for apk in db.query("select Z_PK from ZJOURNALENTRYASSETMO where ZENTRY=?", [pk])
                 .compactMap({ $0.i("Z_PK") }) {
                 db.exec("delete from ZJOURNALENTRYASSETFILEATTACHMENTMO where ZASSET=?", [apk])
@@ -455,7 +468,6 @@ func cmdEmpty(_ a: Args) {
             db.exec("delete from ZJOURNALENTRYASSETMO where ZENTRY=?", [pk])
             db.exec("delete from Z_5JOURNALS where Z_5ENTRIES=?", [pk])
             db.exec("delete from ZJOURNALENTRYMO where Z_PK=?", [pk])
-            markJournalsUnsynced(db, oldJournalPKs)
             if let eu = uString(r.b("ZID")) {
                 try? FileManager.default.removeItem(atPath: attachDir() + "/" + eu)
             }
@@ -473,32 +485,46 @@ func cmdEmpty(_ a: Args) {
 
 func cmdSyncJournals(_ a: Args) {
     let selected = a.value("--journal")
-    if a.has("--dry-run") {
-        let rows: [JournalRow] = withSnapshot { db in
-            if let selected {
-                let journal = resolveJournal(db, selected)
-                if journal.isDefault { die("the default journal has no custom membership record to sync") }
-                return [journal]
-            }
-            return journalRows(db).filter { !$0.isDefault }
-        }
-        print("DRY RUN: would queue \(rows.count) custom journal\(rows.count == 1 ? "" : "s") for membership re-upload. Nothing written.")
-        return
-    }
-
-    let count: Int = withLive(allowLiveDefault: a.has("--live"), acceptRisk: a.has("--accept-risk")) { db in
+    let repairs: [(journal: JournalRow, count: Int64)] = withSnapshot { db in
         let rows: [JournalRow]
         if let selected {
             let journal = resolveJournal(db, selected)
-            if journal.isDefault { die("the default journal has no custom membership record to sync") }
+            if journal.isDefault { die("the default journal has no custom membership to audit") }
             rows = [journal]
         } else {
             rows = journalRows(db).filter { !$0.isDefault }
         }
-        markJournalsUnsynced(db, rows.map(\.pk))
-        return rows.count
+        return rows.compactMap { journal in
+            let count = db.one("""
+                select count(*) as N
+                from Z_5JOURNALS j
+                join ZJOURNALENTRYMO e on e.Z_PK=j.Z_5ENTRIES
+                where j.Z_6JOURNALS=? and e.ZMERGEABLEATTRIBUTES is null
+                  and coalesce(e.ZISFULLYREMOVED,0)=0
+                  and coalesce(e.ZRECENTLYDELETED,0)=0
+                """, [journal.pk])?.i("N") ?? 0
+            return count > 0 ? (journal, count) : nil
+        }
     }
-    print("Queued \(count) custom journal\(count == 1 ? "" : "s") for membership re-upload. Open Journal.app to sync the corrected memberships to other devices.")
+    guard !repairs.isEmpty else {
+        print("No Mac-local custom-journal memberships found.")
+        return
+    }
+    print("Mac-local memberships that require finalization in Journal.app:")
+    for repair in repairs {
+        print("  \(repair.journal.name): \(repair.count) entr\(repair.count == 1 ? "y" : "ies")")
+    }
+    print("""
+
+Direct database relationships do not contain Journal's per-entry iCloud merge data.
+For each journal above:
+  1. In Journal.app, create a new final journal with a different name.
+  2. Open the staging journal, then choose Select Entries > Select All.
+  3. Choose Move / Choose Journals and select the new final journal.
+  4. Wait until the staging journal shows 0 entries and iCloud finishes syncing.
+
+This command is read-only. --live and --dry-run are accepted for compatibility.
+""")
 }
 
 func cmdSandbox(_ a: Args) {

--- a/swift/Sources/journal-cli/main.swift
+++ b/swift/Sources/journal-cli/main.swift
@@ -34,8 +34,8 @@ WRITE (guarded: --live required against the real store; auto-backup first)
   delete    <id> [--hard] [--force] [--live]
   restore   <id> [--live]
   empty     [--force] [--live]
-  sync-journals [--journal NAME] [--live]
-            re-upload custom-journal memberships after a direct-store import
+  sync-journals [--journal NAME]
+            audit Mac-local memberships and print the native sync repair steps
   sandbox   --dir DIR [--from DB]      copy the store somewhere safe for testing
   render    [--body B | --body-file F | stdin] [--plain | --inline]
             render Markdown to RTF (or plain text) on stdout; writes nothing

--- a/tests/test_write.sh
+++ b/tests/test_write.sh
@@ -230,34 +230,39 @@ echo "T12 journals"
 NJ=$(sqlite3 "$DB" "select count(*) from ZJOURNALMO where coalesce(ZUSERDELETED,0)=0;")
 if [ "$NJ" -ge 2 ]; then
   TJPK=$(sqlite3 "$DB" "select Z_PK from ZJOURNALMO where ZMERGEABLEATTRIBUTES is not null limit 1;")
+  TJOPT=$(sqlite3 "$DB" "select Z_OPT from ZJOURNALMO where Z_PK=$TJPK;")
   ok "journals lists both" "$("$CLI" --db "$DB" journals --json | jq_ 'len(d)')" "$NJ"
   ok "name resolved from CRDT" "$("$CLI" --db "$DB" journals --json | jq_ '[j for j in d if j["pk"]=='$TJPK'][0]["name"]')" "Test Journal"
   JOUT=$("$CLI" --db "$DB" write --body "In the test journal." --journal "Test Journal" 2>&1)
   JPK=$(echo "$JOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
   ok "join row written" "$(sqlite3 "$DB" "select Z_6JOURNALS from Z_5JOURNALS where Z_5ENTRIES=$JPK;")" "$TJPK"
-  ok "custom journal queued for sync" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "0"
-  ok "custom journal version bumped" "$(sqlite3 "$DB" "select Z_OPT from ZJOURNALMO where Z_PK=$TJPK;")" "2"
+  ok "write warns membership is local staging" "$(echo "$JOUT" | grep -c 'Mac-local staging membership')" "1"
+  ok "staging write does not fake a journal upload" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "1"
+  ok "staging write leaves journal version unchanged" "$(sqlite3 "$DB" "select Z_OPT from ZJOURNALMO where Z_PK=$TJPK;")" "$TJOPT"
   DOUT=$("$CLI" --db "$DB" write --body "In the default journal." 2>&1)
   DPK=$(echo "$DOUT" | grep -oE 'entry [0-9]+' | grep -oE '[0-9]+')
   ok "default write has no join row" "$(sqlite3 "$DB" "select count(*) from Z_5JOURNALS where Z_5ENTRIES=$DPK;")" "0"
+  ok "default write has no staging warning" "$(echo "$DOUT" | grep -c 'Mac-local staging membership')" "0"
   sqlite3 "$DB" "update ZJOURNALMO set ZISUPLOADEDTOCLOUD=1 where Z_PK=$TJPK;"
-  "$CLI" --db "$DB" edit $DPK --journal "Test Journal" >/dev/null 2>&1
-  ok "edit moves into journal" "$(sqlite3 "$DB" "select Z_6JOURNALS from Z_5JOURNALS where Z_5ENTRIES=$DPK;")" "$TJPK"
-  ok "move queues destination journal" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "0"
-  sqlite3 "$DB" "update ZJOURNALMO set ZISUPLOADEDTOCLOUD=1 where Z_PK=$TJPK;"
+  EOUT=$("$CLI" --db "$DB" edit $DPK --journal "Test Journal" 2>&1)
+  ok "edit stages an unsynced entry in journal" "$(sqlite3 "$DB" "select Z_6JOURNALS from Z_5JOURNALS where Z_5ENTRIES=$DPK;")" "$TJPK"
+  ok "edit warns membership is local staging" "$(echo "$EOUT" | grep -c 'Mac-local staging membership')" "1"
+  ok "staged move does not fake a journal upload" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "1"
   "$CLI" --db "$DB" edit $DPK --journal 1 >/dev/null 2>&1
   ok "edit moves back to default (join row dropped)" "$(sqlite3 "$DB" "select count(*) from Z_5JOURNALS where Z_5ENTRIES=$DPK;")" "0"
-  ok "move queues source journal" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "0"
-  sqlite3 "$DB" "update ZJOURNALMO set ZISUPLOADEDTOCLOUD=1 where Z_PK=$TJPK;"
-  "$CLI" --db "$DB" sync-journals --dry-run >/dev/null 2>&1
-  ok "sync-journals dry-run is read-only" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "1"
-  "$CLI" --db "$DB" sync-journals >/dev/null 2>&1
-  ok "sync-journals repairs existing memberships" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "0"
+  sqlite3 "$DB" "update ZJOURNALENTRYMO set ZMERGEABLEATTRIBUTES=X'01' where Z_PK=$DPK;"
+  "$CLI" --db "$DB" edit $DPK --journal "Test Journal" >/dev/null 2>&1
+  ok "direct journal move refused for CRDT entry" "$?" "1"
+  ok "refused CRDT move is unchanged" "$(sqlite3 "$DB" "select count(*) from Z_5JOURNALS where Z_5ENTRIES=$DPK;")" "0"
+  sqlite3 "$DB" "update ZJOURNALENTRYMO set ZMERGEABLEATTRIBUTES=NULL where Z_PK=$DPK;"
+  AUDIT=$("$CLI" --db "$DB" sync-journals --journal "Test Journal" 2>&1)
+  ok "sync-journals finds local-only membership" "$(echo "$AUDIT" | grep -Ec 'Test Journal: [1-9][0-9]* entr(y|ies)')" "1"
+  ok "sync-journals gives native move instructions" "$(echo "$AUDIT" | grep -c 'Select Entries > Select All')" "1"
+  ok "sync-journals is read-only" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "1"
   "$CLI" --db "$DB" write --body x --journal "No Such Journal" >/dev/null 2>&1
   ok "unknown journal rejected" "$?" "1"
-  sqlite3 "$DB" "update ZJOURNALMO set ZISUPLOADEDTOCLOUD=1 where Z_PK=$TJPK;"
   "$CLI" --db "$DB" delete $JPK --hard >/dev/null 2>&1
-  ok "hard delete queues former journal" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "0"
+  ok "hard delete leaves journal sync state unchanged" "$(sqlite3 "$DB" "select ZISUPLOADEDTOCLOUD from ZJOURNALMO where Z_PK=$TJPK;")" "1"
   "$CLI" --db "$DB" delete $DPK --hard >/dev/null 2>&1
 else
   echo "  SKIP  (seed has one journal)"


### PR DESCRIPTION
## Summary
- replace the ineffective custom-journal upload invalidation with a read-only audit
- warn that direct journal assignments are Mac-local staging memberships
- require Journal.app to author cross-device membership merge data and refuse unsafe direct moves for merge-managed entries
- update the Day One import workflow, reference implementation, docs, and regression coverage

## Validation
- `swift build --package-path swift -c release`
- Swift fixture suite: 170 passed, 0 failed
- Python reference fixture suite: 120 passed, 0 failed
- `python3 -m py_compile reference/journal-cli.py skills/dayone-import/scripts/dayone-import.py`
- `git diff --check`

## Review evidence
- Local self-review: no unresolved blockers
- Repo autoreview: not available
- Codex one-shot review: three documentation/output findings fixed and revalidated